### PR TITLE
Add Draft.js to the write page #65

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "css-loader": "^0.24.0",
     "css-spacing": "^1.0.0",
     "debug": "~2.2.0",
+    "draft-js": "^0.9.1",
+    "draft-js-export-markdown": "^0.2.1",
     "express": "~4.13.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",

--- a/src/post/newPost/NewPost.js
+++ b/src/post/newPost/NewPost.js
@@ -1,96 +1,131 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import formSerialize from 'form-serialize';
+import kebabCase from 'lodash/kebabCase';
 import { Link, browserHistory } from 'react-router';
 
-import Header from './../../app/header';
+import '../../fonts/Karla.scss';
+import '../../fonts/MaterialIcons.scss';
+import './NewPost.scss';
+import Header from '../../app/header';
+import PostEditor from './PostEditor';
 
-export function RawNewPost({createPost, user}) {
-  const author = user.name;
-  return (
-    <div
-      className="main-panel"
-    >
-      <Header menu="messages" />
+export class RawNewPost extends Component {
+  static propTypes = {
+    user: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    createPost: PropTypes.func,
+  };
 
-      <div className="container">
-        <form
-          action="/write"
-          method="post"
-          onSubmit={createPost}
-        >
-          <div>
-            <fieldset className="form-group">
-              <label htmlFor="title">
-                Title
-              </label>
-              <input
-                autoFocus
-                name="title"
-                type="text"
-                className="form-control form-control-lg"
-              />
-            </fieldset>
+  onSubmit(e) {
+    e.preventDefault();
+    e.preventDefault();
+    const data = formSerialize(e.target, {
+      hash: true,
+    });
 
-            <fieldset className="form-group">
-              <label htmlFor="body">Body</label>
-              <textarea
-                name="body"
-                className="form-control form-control-lg"
-              />
-            </fieldset>
+    data.parentAuthor = '';
+    const postBody = this.refs.editor.getContent();
+    data.jsonMetadata = JSON.stringify({
+      post: postBody,
+    });
+    data.body = postBody.markdown;
 
-            <fieldset className="form-group">
-              <label htmlFor="parentPermlink">Category</label>
-              <input
-                type="text"
-                name="parentPermlink"
-                className="form-control form-control-lg"
-              />
-            </fieldset>
-          </div>
+    if (!data.permlink) {
+      data.permlink = kebabCase(data.title);
+    }
 
-          <input
-            name="authorPermlink"
-            type="hidden"
-            value=""
-          />
+    this.props.createPost(data);
+  }
 
-          <input
-            name="author"
-            type="hidden"
-            value={author || ''}
-          />
+  render() {
+    const {
+      user,
+    } = this.props;
+    const author = user.name;
 
-          <div className="form-group">
-            <div className="btn-group">
-              <Link to="/" className="btn btn-default btn-lg">
-                Cancel
-              </Link>
+    return (
+      <div
+        className="main-panel"
+      >
+        <Header menu="messages" />
 
-              <button type="submit" className="btn btn-primary btn-lg">
-                Post
-              </button>
+        <div className="container">
+          <form
+            action="/write"
+            method="post"
+            onSubmit={this.onSubmit.bind(this)}
+          >
+            <div>
+              <fieldset className="form-group">
+                <label htmlFor="title">
+                  Title
+                </label>
+                <input
+                  autoFocus
+                  name="title"
+                  required
+                  type="text"
+                  className="form-control form-control-lg"
+                />
+              </fieldset>
+
+              <fieldset className="form-group">
+                <label htmlFor="body">Body</label>
+                <PostEditor
+                  required
+                  ref="editor"
+                />
+                <hr />
+              </fieldset>
+
+              <fieldset className="form-group">
+                <label htmlFor="parentPermlink">Category</label>
+                <input
+                  type="text"
+                  name="parentPermlink"
+                  required
+                  className="form-control form-control-lg"
+                />
+              </fieldset>
             </div>
-          </div>
-        </form>
+
+            <input
+              name="authorPermlink"
+              type="hidden"
+              value=""
+            />
+
+            <input
+              name="author"
+              type="hidden"
+              value={author || ''}
+            />
+
+            <div className="form-group">
+              <div className="btn-group">
+                <Link to="/" className="btn btn-default btn-lg">
+                  Cancel
+                </Link>
+
+                <button type="submit" className="btn btn-primary btn-lg">
+                  Post
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
-RawNewPost.propTypes = {
-  user: PropTypes.shape({
-    name: PropTypes.string,
-  }),
-  createPost: PropTypes.func,
-};
 
 // TODO - Remove this from here
 // Couldn't find your standard state and action management
 
 import Promise from 'bluebird'; // eslint-disable-line import/imports-first
 import assert from 'assert'; // eslint-disable-line import/imports-first
-import formSerialize from 'form-serialize'; // eslint-disable-line import/imports-first
 import request from 'superagent'; // eslint-disable-line import/imports-first
-import _ from 'lodash'; // eslint-disable-line import/imports-first
 import { connect } from 'react-redux'; // eslint-disable-line import/imports-first
 
 Promise.promisifyAll(request.Request.prototype);
@@ -100,9 +135,10 @@ export const CREATE_POST_START = 'CREATE_POST_START';
 export const CREATE_POST_SUCCESS = 'CREATE_POST_SUCCESS';
 export const CREATE_POST_ERROR = 'CREATE_POST_ERROR';
 
-const requiredFields = 'parentAuthor,parentPermlink,author,permlink,title,body,jsonMetadata'
+const requiredFields =
+  'parentAuthor,parentPermlink,author,permlink,title,body,jsonMetadata'
   .split(',');
-function rawCreatePost(body) {
+function createPost(body) {
   requiredFields.forEach((field) => {
     assert(
       body[field] != null,
@@ -125,20 +161,6 @@ function rawCreatePost(body) {
         }),
     },
   });
-}
-
-// TODO - Use `react-form` and keep form state in the Redux store
-export function createPost(e) {
-  e.preventDefault();
-  const body = formSerialize(e.target, {
-    hash: true,
-  });
-  body.parentAuthor = '';
-  body.jsonMetadata = '';
-  if (!body.permlink) {
-    body.permlink = _.kebabCase(body.title);
-  }
-  return rawCreatePost(body);
 }
 
 const NewPost = connect((state) => ({

--- a/src/post/newPost/NewPost.scss
+++ b/src/post/newPost/NewPost.scss
@@ -1,0 +1,4 @@
+.NewPost__control-group {
+  border: solid 1px rgba(black, 0.15);
+  padding: 15px;
+}

--- a/src/post/newPost/PostEditor.js
+++ b/src/post/newPost/PostEditor.js
@@ -1,0 +1,249 @@
+// Forked from https://github.com/rajaraodv/draftjs-examples
+import React, { Component } from 'react';
+import { Editor, EditorState, RichUtils, convertToRaw, convertFromRaw } from 'draft-js';
+import exportMarkdown from 'draft-js-export-markdown/lib/stateToMarkdown';
+
+import './NewPost.scss';
+import './PostEditor.scss';
+
+// Custom overrides for "code" style.
+const styleMap = {
+  CODE: {
+    backgroundColor: 'rgba(0, 0, 0, 0.05)',
+    fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
+    fontSize: 16,
+    padding: 2,
+  },
+};
+
+function getBlockStyle(block) {
+  switch (block.getType()) {
+    case 'blockquote': return 'PostEditor__blockquote';
+    default: return null;
+  }
+}
+
+const INLINE_STYLES = [
+  {
+    label: 'Bold',
+    style: 'BOLD'
+  },
+  {
+    label: 'Italic',
+    style: 'ITALIC'
+  },
+  {
+    label: 'Underline',
+    style: 'UNDERLINE'
+  },
+  {
+    label: 'Monospace',
+    style: 'CODE'
+  },
+];
+
+const BLOCK_TYPES = [
+  {
+    label: 'H1',
+    style: 'header-one'
+  },
+  {
+    label: 'H2',
+    style: 'header-two'
+  },
+  {
+    label: 'H3',
+    style: 'header-three'
+  },
+  {
+    label: 'H4',
+    style: 'header-four'
+  },
+  {
+    label: 'H5',
+    style: 'header-five'
+  },
+  {
+    label: 'H6',
+    style: 'header-six'
+  },
+  {
+    label: 'Blockquote',
+    style: 'blockquote'
+  },
+  {
+    label: 'UL',
+    style: 'unordered-list-item'
+  },
+  {
+    label: 'OL',
+    style: 'ordered-list-item'
+  },
+  {
+    label: 'Code Block',
+    style: 'code-block'
+  },
+];
+
+export default class PostEditor extends Component {
+  constructor(props) {
+    super(props);
+    const editorState = process.env.NODE_ENV === 'production'
+      ? EditorState.createEmpty()
+      : EditorState.createWithContent(
+          convertFromRaw(require('./test-state.json').raw) // eslint-disable-line
+        );
+
+    this.state = {
+      editorState,
+    };
+  }
+
+  getContent() {
+    return {
+      markdown: exportMarkdown(
+        this.state.editorState.getCurrentContent()
+      ),
+      raw: convertToRaw(this.state.editorState.getCurrentContent()),
+    };
+  }
+
+  focus = () => this.refs.editor.focus(); // eslint-disable-line
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState
+    });
+  };
+
+  handleKeyCommand = (command) => this._handleKeyCommand(command);
+
+  toggleBlockType = (type) => this._toggleBlockType(type);
+
+  toggleInlineStyle = (style) => this._toggleInlineStyle(style);
+
+  _handleKeyCommand(command) {
+    const { editorState } = this.state;
+    const newState = RichUtils.handleKeyCommand(editorState, command);
+    if (newState) {
+      this.onChange(newState);
+      return true;
+    }
+    return false;
+  }
+
+  _toggleBlockType(blockType) {
+    this.onChange(
+      RichUtils.toggleBlockType(
+        this.state.editorState,
+        blockType
+      )
+    );
+  }
+
+  _toggleInlineStyle(inlineStyle) {
+    this.onChange(
+      RichUtils.toggleInlineStyle(
+        this.state.editorState,
+        inlineStyle
+      )
+    );
+  }
+
+  render() {
+    const {
+      editorState,
+    } = this.state;
+
+    // If the user changes block type before entering any text, we can
+    // either style the placeholder or hide it. Let's just hide it now.
+    const className = 'PostEditor__editor';
+
+    return (
+      <div className="PostEditor">
+        <div className="NewPost__control-group">
+          <BlockStyleControls
+            editorState={editorState}
+            onToggle={this.toggleBlockType}
+          />
+
+          <InlineStyleControls
+            editorState={editorState}
+            onToggle={this.toggleInlineStyle}
+          />
+        </div>
+
+        <div className={className} onClick={this.focus}>
+          <Editor
+            blockStyleFn={getBlockStyle}
+            customStyleMap={styleMap}
+            editorState={editorState}
+            handleKeyCommand={this.handleKeyCommand}
+            onChange={this.onChange}
+            ref="editor" // eslint-disable-line
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+class StyleButton extends React.Component {
+  onToggle = (e) => {
+    e.preventDefault();
+    this.props.onToggle(this.props.style);
+  };
+
+  render() {
+    let className = 'PostEditor__styleButton';
+    if (this.props.active) {
+      className += ' PostEditor__activeButton';
+    }
+
+    return (
+      <span className={className} onMouseDown={this.onToggle}>
+        {this.props.label}
+      </span>
+    );
+  }
+}
+
+const BlockStyleControls = (props) => {
+  const { editorState } = props;
+  const selection = editorState.getSelection();
+  const blockType = editorState
+    .getCurrentContent()
+    .getBlockForKey(selection.getStartKey())
+    .getType();
+
+  return (
+    <div className="PostEditor__controls">
+      {BLOCK_TYPES.map((type) =>
+        <StyleButton
+          key={type.label}
+          active={type.style === blockType}
+          label={type.label}
+          onToggle={props.onToggle}
+          style={type.style}
+        />
+      )}
+    </div>
+  );
+};
+
+const InlineStyleControls = (props) => {
+  const currentStyle = props.editorState.getCurrentInlineStyle();
+  return (
+    <div className="PostEditor__controls">
+      {INLINE_STYLES.map(type =>
+        <StyleButton
+          key={type.label}
+          active={currentStyle.has(type.style)}
+          label={type.label}
+          onToggle={props.onToggle}
+          style={type.style}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/post/newPost/PostEditor.scss
+++ b/src/post/newPost/PostEditor.scss
@@ -1,0 +1,104 @@
+.PostEditor {
+  $font-primary: 'Karla', sans-serif;
+
+  background: #fff;
+  font-size: 14px;
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: $font-primary;
+    margin-bottom: 0;
+  }
+
+  h1 {
+    font-size: 4em;
+  }
+
+  h2 {
+    font-size: 3em;
+  }
+
+  h3 {
+    font-size: 2.5em;
+  }
+
+
+  h4 {
+    font-size: 2em;
+  }
+
+  pre {
+    margin-bottom: 0;
+  }
+
+  ul {
+    padding-left: 20px;
+
+    li {
+      list-style: initial;
+    }
+  }
+
+  ol {
+    padding-left: 20px;
+
+    li {
+      list-style: initial;
+      list-style-type: decimal;
+    }
+  }
+
+  blockquote {
+    font-family: $font-primary;
+  }
+
+  .PostEditor__blockquote {
+    border-left: 5px solid #eee;
+    color: #666;
+    font-style: italic;
+    margin: 16px 0;
+    padding: 10px 20px;
+  }
+
+  .PostEditor__editor {
+    cursor: text;
+    font-size: 16px;
+    margin-top: 10px;
+  }
+
+  .PostEditor__editor .public-DraftEditorPlaceholder-root,
+  .PostEditor__editor .public-DraftEditor-content {
+    margin: 0 -15px -15px;
+    padding: 15px;
+  }
+
+  .PostEditor__editor .public-DraftEditor-content {
+    min-height: 100px;
+  }
+
+  .PostEditor__hidePlaceholder .public-DraftEditorPlaceholder-root {
+    display: none;
+  }
+
+  .PostEditor__editor .public-DraftStyleDefault-pre {
+    background-color: rgba(0, 0, 0, 0.05);
+    font-size: 16px;
+    padding: 20px;
+  }
+
+  .PostEditor__controls {
+    font-size: 14px;
+    user-select: none;
+  }
+
+  .PostEditor__styleButton {
+    color: #999;
+    cursor: pointer;
+    margin-right: 16px;
+    padding: 2px 0;
+    display: inline-block;
+  }
+
+  .PostEditor__activeButton {
+    color: #5890ff;
+  }
+}

--- a/src/post/newPost/test-state.json
+++ b/src/post/newPost/test-state.json
@@ -1,0 +1,248 @@
+{
+  "markdown": "# Header 1\n\n## Header 2\n\n### Header 3\n\n#### Header 4\n\n##### Header 5\n\n###### Header 6\n\n > Lorem Ipsum BlockQuote\n\n- Unordered\n- List\n- Here\n\n\n1. One - Ordered\n2. Two - List\n3. Three - Here\n\n    ;; A pretty code block\n\n    main = **do**\n\n        toDockerfileStr $ **do**\n\n    **        **from \"node\" \\`tagged\\` \"6\"\n\n            ;; --\n\n**Bold text** among non-bold text\n\n_Italic text _among non-italic text\n\n++Underlined text ++with non-underlined text\n\n`Monospace text `with non-monospace text\n",
+  "raw": {
+    "entityMap": {},
+    "blocks": [
+      {
+        "key": "rims",
+        "text": "Header 1",
+        "type": "header-one",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "d2965",
+        "text": "Header 2",
+        "type": "header-two",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "ea65f",
+        "text": "Header 3",
+        "type": "header-three",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "fii7",
+        "text": "Header 4",
+        "type": "header-four",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "ebhcv",
+        "text": "Header 5",
+        "type": "header-five",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "593mb",
+        "text": "Header 6",
+        "type": "header-six",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "3skgn",
+        "text": "Lorem Ipsum BlockQuote",
+        "type": "blockquote",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "528d7",
+        "text": "Unordered",
+        "type": "unordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "4ucdm",
+        "text": "List",
+        "type": "unordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "75i8o",
+        "text": "Here",
+        "type": "unordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "auckd",
+        "text": "One - Ordered",
+        "type": "ordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "dobg5",
+        "text": "Two - List",
+        "type": "ordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "848ug",
+        "text": "Three - Here",
+        "type": "ordered-list-item",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "34mhm",
+        "text": ";; A pretty code block",
+        "type": "code-block",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "6uksv",
+        "text": "main = do",
+        "type": "code-block",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 7,
+            "length": 2,
+            "style": "BOLD"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "b7vf4",
+        "text": "    toDockerfileStr $ do",
+        "type": "code-block",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 22,
+            "length": 2,
+            "style": "BOLD"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "3avjd",
+        "text": "        from \"node\" `tagged` \"6\"",
+        "type": "code-block",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 0,
+            "length": 8,
+            "style": "BOLD"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "6ogv9",
+        "text": "        ;; --",
+        "type": "code-block",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "dscls",
+        "text": "Bold text among non-bold text",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 0,
+            "length": 9,
+            "style": "BOLD"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "5p9tv",
+        "text": "Italic text among non-italic text",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 0,
+            "length": 12,
+            "style": "ITALIC"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "4q9s0",
+        "text": "Underlined text with non-underlined text",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 0,
+            "length": 16,
+            "style": "UNDERLINE"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      },
+      {
+        "key": "4hgqp",
+        "text": "Monospace text with non-monospace text",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [
+          {
+            "offset": 0,
+            "length": 15,
+            "style": "CODE"
+          }
+        ],
+        "entityRanges": [],
+        "data": {}
+      }
+    ]
+  }
+}

--- a/src/styles/base.sass
+++ b/src/styles/base.sass
@@ -1,5 +1,5 @@
-@import '../fonts/Karla.scss';
-@import '../fonts/MaterialIcons.scss';
+@import '../fonts/Karla.scss'
+@import '../fonts/MaterialIcons.scss'
 
 $font-primary: 'Karla', sans-serif
 $font-alt: 'Circular-Bold', 'Helvetica Neue', sans-serif


### PR DESCRIPTION
Took a rich editor example and added it, supporting:
- h1-h6
- ul & ol
- em, b, blockquote, code
- pre, code
- underlined

It tries to render the content as markdown and submits it as the body.
Also stores serialized Draft.js state on the `json_metadata`.

On development an example Draft.js state that could be loaded from
`json_metadata` is loaded from a JSON file.
