### PR TITLE
Fix URL replace regex

### DIFF
--- a/src/post/BodyShort.js
+++ b/src/post/BodyShort.js
@@ -11,7 +11,7 @@ function decodeEntities(body) {
 
 const BodyShort = (props) => {
   let body = striptags(remarkable.render(decodeEntities(props.body)));
-  body = body.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '');
+  body = body.replace(/(?:https?|ftp):\/\/[\S]+/g, '');
   return (<span>
     <span dangerouslySetInnerHTML={{ __html: ellipsis(body, 140, { ellipsis: '…' }) }} />
   </span>);


### PR DESCRIPTION
Current regex deletes next word on new line that occurs behind url (in this case The is missing).
**Before:**
![image](https://user-images.githubusercontent.com/1968722/26934753-8aefee38-4c6a-11e7-8700-8d8a3ca85655.png)
**After:**
![image](https://user-images.githubusercontent.com/1968722/26934764-930a0de2-4c6a-11e7-8160-accaff73221c.png)

See: https://busy.org/@bitspace for posts with that problem.

