### PR TITLE
Striptags before passing it to remarkable

### DIFF
--- a/src/post/BodyShort.js
+++ b/src/post/BodyShort.js
@@ -10,7 +10,7 @@ function decodeEntities(body) {
 }
 
 const BodyShort = (props) => {
-  let body = striptags(remarkable.render(decodeEntities(props.body)));
+  let body = striptags(remarkable.render(striptags(decodeEntities(props.body))));
   body = body.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '');
   return (<span>
     <span dangerouslySetInnerHTML={{ __html: ellipsis(body, 140, { ellipsis: '…' }) }} />


### PR DESCRIPTION
This should prevent crash when rendering `BodyShort` with many backslashes