### PR TITLE
Integrate fix from #535

### DIFF
--- a/src/components/Story/BodyShort.js
+++ b/src/components/Story/BodyShort.js
@@ -10,7 +10,7 @@ function decodeEntities(body) {
 }
 
 const BodyShort = (props) => {
-  let body = striptags(remarkable.render(decodeEntities(props.body)));
+  let body = striptags(remarkable.render(striptags(decodeEntities(props.body))));
   body = body.replace(/(?:https?|ftp):\/\/[\S]+/g, '');
   return (<span>
     <span dangerouslySetInnerHTML={{ __html: ellipsis(body, 140, { ellipsis: '…' }) }} />


### PR DESCRIPTION
New design uses own version of `BodyShort` . This PR integrates #535 fix to that component.