### PR TITLE
Add margin to StoryLoading

### DIFF
--- a/src/components/Story/StoryLoading.less
+++ b/src/components/Story/StoryLoading.less
@@ -10,6 +10,10 @@
   color: #353535;
   border: solid 1px #e9e7e7;
 
+  &:not(:nth-child(1)) {
+    margin-top: 10px;
+  }
+
   &__header {
     padding: 16px;
     display: flex;


### PR DESCRIPTION
StoryLoading is missing top margin this adds this to every not-first child StoryLoading.
![peek 2017-06-13 09-58](https://user-images.githubusercontent.com/1968722/27072501-d775d1aa-5020-11e7-92df-9c72af82a5f4.gif)
