### PR TITLE
Add PopoverMenu to collapsed menu

### DIFF
--- a/src/components/Navigation/Topnav.js
+++ b/src/components/Navigation/Topnav.js
@@ -4,9 +4,8 @@ import { Link } from 'react-router';
 import { Menu, Popover, Tooltip, Input, Badge } from 'antd';
 import Avatar from '../Avatar';
 import Notifications from './Notifications/Notifications';
+import PopoverMenu, { PopoverMenuItem } from '../PopoverMenu/PopoverMenu';
 import './Topnav.less';
-
-const SubMenu = Menu.SubMenu;
 
 const Topnav = ({ username, onNotificationClick, onSeeAllClick, notifications }) => {
   let content;
@@ -56,11 +55,21 @@ const Topnav = ({ username, onNotificationClick, onSeeAllClick, notifications })
               </Tooltip>
             </Popover>
           </Menu.Item>
-          <SubMenu key="more" className="Topnav__item--dropdown" title={<i className="iconfont icon-switch" />}>
-            <Menu.Item className="Topnav__item__subitem" key="activity">Activity</Menu.Item>
-            <Menu.Item className="Topnav__item__subitem" key="settings">Settings</Menu.Item>
-            <Menu.Item className="Topnav__item__subitem" key="logout">Logout</Menu.Item>
-          </SubMenu>
+          <Menu.Item key="more" className="Topnav__item--dropdown">
+            <Popover
+              placement="bottom"
+              trigger="click"
+              content={
+                <PopoverMenu>
+                  <PopoverMenuItem>Activity</PopoverMenuItem>
+                  <PopoverMenuItem>Settings</PopoverMenuItem>
+                  <PopoverMenuItem>Logout</PopoverMenuItem>
+                </PopoverMenu>
+              }
+            >
+              <i className="iconfont icon-switch" />
+            </Popover>
+          </Menu.Item>
         </Menu>
       </div>);
   } else {

--- a/src/components/Navigation/Topnav.js
+++ b/src/components/Navigation/Topnav.js
@@ -7,7 +7,7 @@ import Notifications from './Notifications/Notifications';
 import PopoverMenu, { PopoverMenuItem } from '../PopoverMenu/PopoverMenu';
 import './Topnav.less';
 
-const Topnav = ({ username, onNotificationClick, onSeeAllClick, notifications }) => {
+const Topnav = ({ username, onNotificationClick, onSeeAllClick, onMenuItemClick, notifications }) => {
   let content;
 
   const notificationsCount = notifications && notifications
@@ -60,10 +60,10 @@ const Topnav = ({ username, onNotificationClick, onSeeAllClick, notifications })
               placement="bottom"
               trigger="click"
               content={
-                <PopoverMenu>
-                  <PopoverMenuItem>Activity</PopoverMenuItem>
-                  <PopoverMenuItem>Settings</PopoverMenuItem>
-                  <PopoverMenuItem>Logout</PopoverMenuItem>
+                <PopoverMenu onSelect={onMenuItemClick}>
+                  <PopoverMenuItem key="activity">Activity</PopoverMenuItem>
+                  <PopoverMenuItem key="settings">Settings</PopoverMenuItem>
+                  <PopoverMenuItem key="logout">Logout</PopoverMenuItem>
                 </PopoverMenu>
               }
             >
@@ -117,6 +117,7 @@ Topnav.propTypes = {
   username: PropTypes.string,
   onNotificationClick: PropTypes.func,
   onSeeAllClick: PropTypes.func,
+  onMenuItemClick: PropTypes.func,
   notifications: PropTypes.arrayOf(
     PropTypes.shape(),
   ),
@@ -125,6 +126,7 @@ Topnav.propTypes = {
 Topnav.defaultProps = {
   onNotificationClick: () => {},
   onSeeAllClick: () => {},
+  onMenuItemClick: () => {},
 };
 
 export default Topnav;

--- a/src/components/Navigation/Topnav.less
+++ b/src/components/Navigation/Topnav.less
@@ -91,18 +91,6 @@
   }
 }
 
-.Topnav__item__subitem {
-  font-size: 14px !important;
-  font-weight: bold !important;
-  color: #99aab5 !important;
-  height: 30px !important;
-  line-height: 30px !important;
-
-  &:hover {
-    color: @purple !important;
-  }
-}
-
 .Topnav__item--badge {
   top: -1px !important;
 }
@@ -123,13 +111,4 @@
 
 .Topnav__item--dropdown {
   border-bottom: none !important;
-
-  & > ul {
-    padding: 8px 0 !important;
-    left: -36px !important;
-  }
-
-  & > div {
-    padding: 0 2px !important;
-  }
 }

--- a/src/components/PopoverMenu/PopoverMenu.js
+++ b/src/components/PopoverMenu/PopoverMenu.js
@@ -1,15 +1,16 @@
 import React, { PropTypes } from 'react';
 import './PopoverMenu.less';
 
-const PopoverMenuItem = ({ children, key, onClick }) =>
-  <li key={key} onClick={() => onClick(key)}>{children}</li>;
+const PopoverMenuItem = ({ itemKey, children, onClick }) =>
+  <li key={itemKey} onClick={() => onClick(itemKey)}>{children}</li>;
 
 PopoverMenuItem.propTypes = {
   children: PropTypes.oneOfType([
+    PropTypes.array,
     PropTypes.element,
     PropTypes.string,
   ]),
-  key: PropTypes.string.isRequired,
+  itemKey: PropTypes.string,
   onClick: PropTypes.func,
 };
 
@@ -21,14 +22,18 @@ const PopoverMenu = ({ children, onSelect }) =>
   <ul className="PopoverMenu">
     {
       children && Array.isArray(children) && children.map(child =>
-        <PopoverMenuItem key={child.key} onClick={() => onSelect(child.key)}>
+        <PopoverMenuItem key={child.key} itemKey={child.key} onClick={() => onSelect(child.key)}>
           {child.props.children}
         </PopoverMenuItem>)
     }
     {
       children
         && !Array.isArray(children)
-        && <PopoverMenuItem key={children.key} onClick={() => onSelect(children.key)}>
+        && <PopoverMenuItem
+          key={children.key}
+          itemKey={children.key}
+          onClick={() => onSelect(children.key)}
+        >
           {children.props.children}
         </PopoverMenuItem>
     }
@@ -36,7 +41,7 @@ const PopoverMenu = ({ children, onSelect }) =>
 
 PopoverMenu.propTypes = {
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.instanceOf(PopoverMenuItem)),
+    PropTypes.array,
     PropTypes.instanceOf(PopoverMenuItem),
   ]),
   onSelect: PropTypes.func,

--- a/src/components/PopoverMenu/PopoverMenu.js
+++ b/src/components/PopoverMenu/PopoverMenu.js
@@ -1,0 +1,28 @@
+import React, { PropTypes } from 'react';
+import './PopoverMenu.less';
+
+const PopoverMenuItem = ({ children }) =>
+  <li>{children}</li>;
+
+PopoverMenuItem.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+  ]),
+};
+
+const PopoverMenu = ({ children }) =>
+  <ul className="PopoverMenu">
+    {children}
+  </ul>;
+
+PopoverMenu.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.instanceOf(PopoverMenuItem)),
+    PropTypes.instanceOf(PopoverMenuItem),
+    PropTypes.string,
+  ]),
+};
+
+export default PopoverMenu;
+export { PopoverMenuItem };

--- a/src/components/PopoverMenu/PopoverMenu.js
+++ b/src/components/PopoverMenu/PopoverMenu.js
@@ -1,27 +1,49 @@
 import React, { PropTypes } from 'react';
 import './PopoverMenu.less';
 
-const PopoverMenuItem = ({ children }) =>
-  <li>{children}</li>;
+const PopoverMenuItem = ({ children, key, onClick }) =>
+  <li key={key} onClick={() => onClick(key)}>{children}</li>;
 
 PopoverMenuItem.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.string,
   ]),
+  key: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
 };
 
-const PopoverMenu = ({ children }) =>
+PopoverMenuItem.defaultProps = {
+  onClick: () => {},
+};
+
+const PopoverMenu = ({ children, onSelect }) =>
   <ul className="PopoverMenu">
-    {children}
+    {
+      children && Array.isArray(children) && children.map(child =>
+        <PopoverMenuItem key={child.key} onClick={() => onSelect(child.key)}>
+          {child.props.children}
+        </PopoverMenuItem>)
+    }
+    {
+      children
+        && !Array.isArray(children)
+        && <PopoverMenuItem key={children.key} onClick={() => onSelect(children.key)}>
+          {children.props.children}
+        </PopoverMenuItem>
+    }
   </ul>;
 
 PopoverMenu.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.instanceOf(PopoverMenuItem)),
     PropTypes.instanceOf(PopoverMenuItem),
-    PropTypes.string,
   ]),
+  onSelect: PropTypes.func,
+};
+
+PopoverMenu.defaultProps = {
+  onSelect: () => {},
 };
 
 export default PopoverMenu;

--- a/src/components/PopoverMenu/PopoverMenu.less
+++ b/src/components/PopoverMenu/PopoverMenu.less
@@ -1,7 +1,7 @@
 @import "../../styles/custom.less";
 
 .PopoverMenu {
-  & > li, & > li > a {
+  & > li {
     font-size: 14px !important;
     font-weight: bold !important;
     color: #99aab5 !important;

--- a/src/components/PopoverMenu/PopoverMenu.less
+++ b/src/components/PopoverMenu/PopoverMenu.less
@@ -10,6 +10,7 @@
 
     &:hover {
       color: @purple !important;
+      cursor: pointer;
     }
   }
 

--- a/src/components/PopoverMenu/PopoverMenu.less
+++ b/src/components/PopoverMenu/PopoverMenu.less
@@ -1,0 +1,21 @@
+@import "../../styles/custom.less";
+
+.PopoverMenu {
+  & > li, & > li > a {
+    font-size: 14px !important;
+    font-weight: bold !important;
+    color: #99aab5 !important;
+    height: 30px !important;
+    line-height: 30px !important;
+
+    &:hover {
+      color: @purple !important;
+    }
+  }
+
+  & .iconfont {
+    font-size: 20px;
+    vertical-align: -2px;
+    margin-right: 8px;
+  }
+}

--- a/src/components/Story/Story.js
+++ b/src/components/Story/Story.js
@@ -1,14 +1,13 @@
 import React, { PropTypes } from 'react';
 import { FormattedRelative } from 'react-intl';
-import { Menu } from 'antd';
+import { Popover } from 'antd';
 import { Link } from 'react-router';
 import StoryPreview from './StoryPreview';
 import StoryFooter from './StoryFooter';
 import Avatar from '../Avatar';
 import Topic from '../Button/Topic';
+import PopoverMenu, { PopoverMenuItem } from '../PopoverMenu/PopoverMenu';
 import './Story.less';
-
-const SubMenu = Menu.SubMenu;
 
 class Story extends React.Component {
   static propTypes = {
@@ -34,8 +33,8 @@ class Story extends React.Component {
     userFollowed: false,
   };
 
-  handleClick = (e) => {
-    switch (e.key) {
+  handleClick = (key) => {
+    switch (key) {
       case 'follow':
         this.props.onFollowClick();
         return;
@@ -62,18 +61,24 @@ class Story extends React.Component {
 
     return (
       <div className="Story">
-        <Menu
-          onClick={this.handleClick}
-          selectedKeys={[]}
-          className="Story__more"
-          mode="horizontal"
+        <Popover
+          trigger="click"
+          content={
+            <PopoverMenu onSelect={this.handleClick}>
+              <PopoverMenuItem key="follow">
+                <i className="iconfont icon-people" /> {(!userFollowed) ? 'Follow' : 'Unfollow'} {post.author}
+              </PopoverMenuItem>
+              <PopoverMenuItem key="save">
+                <i className="iconfont icon-collection" /> Save post
+              </PopoverMenuItem>
+              <PopoverMenuItem key="report">
+                <i className="iconfont icon-flag" /> Report post
+              </PopoverMenuItem>
+            </PopoverMenu>
+          }
         >
-          <SubMenu className="Story__more__item" title={<i className="iconfont icon-unfold Story__more__icon" />}>
-            <Menu.Item key="follow"><i className="iconfont icon-people Story__submenu__icon" /> {(!userFollowed) ? 'Follow' : 'Unfollow'} {post.author}</Menu.Item>
-            <Menu.Item key="save"><i className="iconfont icon-collection Story__submenu__icon" /> Save post</Menu.Item>
-            <Menu.Item key="report"><i className="iconfont icon-flag Story__submenu__icon" /> Report post</Menu.Item>
-          </SubMenu>
-        </Menu>
+          <i className="iconfont icon-unfold Story__more" />
+        </Popover>
         <div className="Story__header">
           <Link to={`/@${post.author}`}>
             <Avatar username={post.author} size={40} />

--- a/src/components/Story/Story.js
+++ b/src/components/Story/Story.js
@@ -95,7 +95,7 @@ class Story extends React.Component {
             <Topic name={post.category} />
           </div>
         </div>
-        <div className="Story__content" ref={(div) => { this.contentDiv = div; }} onClick={this.onContentClick}>
+        <div className="Story__content">
           <Link to={post.url}>
             <h2 className="Story__content__title">{post.title}</h2>
           </Link>

--- a/src/components/Story/Story.less
+++ b/src/components/Story/Story.less
@@ -10,11 +10,6 @@
   color: #353535;
   border: solid 1px #e9e7e7;
 
-  &__submenu__icon {
-    font-size: 20px !important;
-    vertical-align: -1px;
-  }
-
   &__more {
     position: absolute;
     right: 16px;

--- a/src/components/Story/Story.less
+++ b/src/components/Story/Story.less
@@ -13,9 +13,15 @@
   &__more {
     position: absolute;
     right: 16px;
-    top: 16px;
+    top: 20px;
     font-size: 20px !important;
     color: #c2ccd3;
+    line-height: 12px;
+
+    &:hover {
+      cursor: pointer;
+      color: darken(#c2ccd3, 15%);
+    }
   }
 
   &__header {

--- a/src/components/Story/Story.less
+++ b/src/components/Story/Story.less
@@ -18,26 +18,9 @@
   &__more {
     position: absolute;
     right: 16px;
-    top: 4px;
-    background-color: transparent !important;
-    border-bottom: none !important;
-
-    &__item {
-      border-bottom: none !important;
-
-      & > ul {
-        left: -128px !important;
-      }
-
-      & > div {
-        padding: 0 2px !important;
-      }
-    }
-
-    &__icon {
-      font-size: 20px !important;
-      color: #c2ccd3;
-    }
+    top: 16px;
+    font-size: 20px !important;
+    color: #c2ccd3;
   }
 
   &__header {

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -2,15 +2,14 @@ import React, { PropTypes } from 'react';
 import _ from 'lodash';
 import { FormattedRelative } from 'react-intl';
 import { Link } from 'react-router';
-import { Menu } from 'antd';
+import { Popover } from 'antd';
 import Lightbox from 'react-image-lightbox';
 import Body from './Body';
 import StoryFooter from './StoryFooter';
 import Avatar from '../Avatar';
 import Topic from '../Button/Topic';
+import PopoverMenu, { PopoverMenuItem } from '../PopoverMenu/PopoverMenu';
 import './StoryFull.less';
-
-const SubMenu = Menu.SubMenu;
 
 class StoryFull extends React.Component {
   static propTypes = {
@@ -48,8 +47,8 @@ class StoryFull extends React.Component {
     };
   }
 
-  handleClick = (e) => {
-    switch (e.key) {
+  handleClick = (key) => {
+    switch (key) {
       case 'follow':
         this.props.onFollowClick();
         return;
@@ -113,18 +112,25 @@ class StoryFull extends React.Component {
               <FormattedRelative value={`${post.created}Z`} />
             </span>
           </div>
-          <Menu
-            onClick={this.handleClick}
-            selectedKeys={[]}
-            className="StoryFull__header__more"
-            mode="horizontal"
+          <Popover
+            placement="bottom"
+            trigger="click"
+            content={
+              <PopoverMenu onSelect={this.handleClick}>
+                <PopoverMenuItem key="follow">
+                  <i className="iconfont icon-people" /> {(!userFollowed) ? 'Follow' : 'Unfollow'} {post.author}
+                </PopoverMenuItem>
+                <PopoverMenuItem key="save">
+                  <i className="iconfont icon-collection" /> Save post
+                </PopoverMenuItem>
+                <PopoverMenuItem key="report">
+                  <i className="iconfont icon-flag" /> Report post
+                </PopoverMenuItem>
+              </PopoverMenu>
+            }
           >
-            <SubMenu className="StoryFull__header__more__item" title={<i className="iconfont icon-more StoryFull__header__more__icon" />}>
-              <Menu.Item key="follow"><i className="iconfont icon-people StoryFull__submenu__icon" /> {(!userFollowed) ? 'Follow' : 'Unfollow'} {post.author}</Menu.Item>
-              <Menu.Item key="save"><i className="iconfont icon-collection StoryFull__submenu__icon" /> Save post</Menu.Item>
-              <Menu.Item key="report"><i className="iconfont icon-flag StoryFull__submenu__icon" /> Report post</Menu.Item>
-            </SubMenu>
-          </Menu>
+            <i className="iconfont icon-more StoryFull__header__more" />
+          </Popover>
         </div>
         <div className="StoryFull__content" ref={(div) => { this.contentDiv = div; }} onClick={this.onContentClick}>
           <Body body={post.body} json_metadata={post.json_metadata} />

--- a/src/components/Story/StoryFull.less
+++ b/src/components/Story/StoryFull.less
@@ -4,11 +4,6 @@
   max-width: 710px;
   margin: 0 auto;
 
-  &__submenu__icon {
-    font-size: 20px !important;
-    vertical-align: -1px;
-  }
-
   &__title {
     color: #353535;
     font-size: 26px;
@@ -52,25 +47,14 @@
     &__more {
       position: absolute;
       right: 0;
-      top: 24px;
-      background-color: transparent !important;
-      border-bottom: none !important;
+      top: 36px;
+      line-height: 12px !important;
+      font-size: 36px !important;
+      color: @purple;
 
-      &__item {
-        border-bottom: none !important;
-
-        & > ul {
-          left: -128px !important;
-        }
-
-        & > div {
-          padding: 0 2px !important;
-        }
-      }
-
-      &__icon {
-        font-size: 36px !important;
-        color: @purple;
+      &:hover {
+        cursor: pointer;
+        color: darken(@purple, 15%);
       }
     }
   }

--- a/src/components/UserHeader.js
+++ b/src/components/UserHeader.js
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react';
-import { Menu } from 'antd';
+import { Popover } from 'antd';
 import Avatar from './Avatar';
 import Follow from './Button/Follow';
+import PopoverMenu, { PopoverMenuItem } from './PopoverMenu/PopoverMenu';
 import './UserHeader.less';
-
-const SubMenu = Menu.SubMenu;
 
 const UserHeader = ({ username }) =>
   <div className="UserHeader">
@@ -16,15 +15,19 @@ const UserHeader = ({ username }) =>
           <div className="UserHeader__user__button">
             <Follow />
           </div>
-          <Menu
-            className="UserHeader__menu"
-            mode="horizontal"
+          <Popover
+            placement="bottom"
+            trigger="click"
+            content={
+              <PopoverMenu>
+                <PopoverMenuItem key="option1">Option 1</PopoverMenuItem>
+                <PopoverMenuItem key="option2">Option 2</PopoverMenuItem>
+                <PopoverMenuItem key="option3">Option 3</PopoverMenuItem>
+              </PopoverMenu>
+            }
           >
-            <SubMenu className="UserHeader__menu__item" title={<i className="iconfont icon-more UserHeader__more" />}>
-              <Menu.Item key="setting:1">Option 1</Menu.Item>
-              <Menu.Item key="setting:2">Option 2</Menu.Item>
-            </SubMenu>
-          </Menu>
+            <i className="iconfont icon-more UserHeader__more" />
+          </Popover>
         </div>
         <div className="UserHeader__row UserHeader__handle">
           @{username}

--- a/src/components/UserHeader.less
+++ b/src/components/UserHeader.less
@@ -2,6 +2,16 @@
 
 .UserHeader {
   background-color: #f3f4f6;
+
+  &__more {
+    font-size: 36px !important;
+    color: @purple;
+
+    &:hover {
+      cursor: pointer;
+      color: darken(@purple, 15%);
+    }
+  }
 }
 
 .UserHeader__container {
@@ -44,25 +54,4 @@
   position: relative;
   top: 12px;
   margin-right: 10px;
-}
-
-.UserHeader__menu {
-  position: relative;
-  top: 3px;
-  background-color: transparent !important;
-  border-bottom: none !important;
-  height: 46px !important;
-}
-
-.UserHeader__menu__item {
-  border-bottom: none !important;
-
-  & > div {
-    padding: 0 2px !important;
-  }
-}
-
-.UserHeader__more {
-  color: @purple;
-  font-size: 36px !important;
 }

--- a/src/stories.js
+++ b/src/stories.js
@@ -54,6 +54,7 @@ storiesOf('Navigation', module)
     notifications={notifications}
     onNotificationClick={action('Notification click')}
     onSeeAllClick={action('SeeAll click')}
+    onMenuItemClick={action('Menu item click')}
   />)
   .add('Sidenav unlogged', () => <Sidenav />)
   .add('Sidenav logged', () => <Sidenav username="guest123" />);

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -33,9 +33,6 @@
 @btn-height-lg: 46px;
 @btn-height-sm: 25px;
 
-// Popover
-@popover-distance: 24px;
-
 // Tooltip
 @tooltip-bg: @purple;
 @tooltip-arrow-color: @purple;


### PR DESCRIPTION
Antd's `Menu` doesn't play nicely with Popovers and is impossible to customize in non-invasive way. This PR adds custom `PopoverMenu` that can be easily styled and doesn't interfere with antd's `Menu`.

**Topnav**:
![peek 2017-06-13 14-01](https://user-images.githubusercontent.com/1968722/27081468-cb3d5dc0-5040-11e7-98b8-4be10b409b01.gif)

**Story**:
![peek 2017-06-13 14-03](https://user-images.githubusercontent.com/1968722/27081533-233a4f56-5041-11e7-9550-279f17ee520c.gif)

**StoryFull**:
![peek 2017-06-13 14-04](https://user-images.githubusercontent.com/1968722/27081553-3b9468f2-5041-11e7-9f12-022fc67ad64c.gif)

**UserHeader**:
![peek 2017-06-13 14-05](https://user-images.githubusercontent.com/1968722/27081588-5d6b47a2-5041-11e7-9ffc-553e7e5374bf.gif)
