### PR TITLE
Redirect to /404 after server side error

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -103,7 +103,7 @@ function serverSideResponse(req, res) {
     fetchComponentData(store.dispatch, props.components, props.params)
       .then(() => renderPage(store, props))
       .then(html => res.end(html))
-      .catch(error => res.end(error.message));
+      .catch(() => res.redirect('/404'));
   });
 }
 


### PR DESCRIPTION
Error displayed on visiting non existing user is caused by `getFeedContent`. Currently server returns `error.message` which probably is not ideal. This PR redirects user to `/4o4` after error, but it's not ideal solution as well.
I think we should discuss the way to handle such errors with serverside rendering.