### PR TITLE
Scroll to top on feed page

### DIFF
--- a/src/components/Utils/ScrollToTop.js
+++ b/src/components/Utils/ScrollToTop.js
@@ -1,0 +1,20 @@
+import React, { PropTypes } from 'react';
+import { withRouter } from 'react-router';
+
+class ScrollToTop extends React.Component {
+  static propTypes = {
+    location: PropTypes.shape().isRequired,
+  }
+
+  componentDidUpdate(prevProps) {
+    if (window && this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/feed/Page.js
+++ b/src/feed/Page.js
@@ -23,6 +23,7 @@ import EmptyFeed from '../statics/EmptyFeed';
 import { LeftSidebar, RightSidebar } from '../app/Sidebar/index';
 import TopicSelector from '../components/TopicSelector';
 import Affix from '../components/Utils/Affix';
+import ScrollToTop from '../components/Utils/ScrollToTop';
 
 class TopicSelectorImpl extends React.Component {
   static propTypes = {
@@ -133,6 +134,7 @@ export default class Page extends React.Component {
         <Helmet>
           <title>Busy</title>
         </Helmet>
+        <ScrollToTop />
         <div className="shifted">
           <div className="feed-layout container">
             <Affix className="leftContainer" stickPosition={77}>


### PR DESCRIPTION
This PR adds ScrollToTop component per react-router 4 [documentation](https://reacttraining.com/react-router/web/guides/scroll-restoration) and adds it to feed page (which fixes bug with unnatural scrolling behavior).