### PR TITLE
Add overflow-y to pre inside story body

### DIFF
--- a/src/__snapshots__/stories.test.js.snap
+++ b/src/__snapshots__/stories.test.js.snap
@@ -8655,7 +8655,9 @@ exports[`Storyshots Story Full story 1`] = `
       className="StoryFull__content"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="Body"
+      >
         <div
           dangerouslySetInnerHTML={
             Object {
@@ -8890,7 +8892,9 @@ exports[`Storyshots Story Full story with embed 1`] = `
       className="StoryFull__content"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="Body"
+      >
         <div
           dangerouslySetInnerHTML={
             Object {

--- a/src/components/Story/Body.js
+++ b/src/components/Story/Body.js
@@ -9,6 +9,7 @@ import sanitizeConfig from '../../helpers/SanitizeConfig';
 import { imageRegex } from '../../helpers/regexHelpers';
 import htmlReady from '../../helpers/steemitHtmlReady';
 import PostFeedEmbed from './PostFeedEmbed';
+import './Body.less';
 
 const remarkable = new Remarkable({
   html: true, // remarkable renders first then sanitize runs...
@@ -60,5 +61,5 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object') {
 
 export default (props) => {
   const htmlSections = getHtml(props.body, props.jsonMetadata);
-  return <div>{htmlSections}</div>;
+  return <div className="Body">{htmlSections}</div>;
 };

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -1,0 +1,5 @@
+.Body {
+  pre {
+    overflow-y: auto;
+  }
+}


### PR DESCRIPTION
Code inside `pre` blocks can overflow content and be displayed offscreen.
See example code [there](https://busy5-pr-506.herokuapp.com/steemscript/@fabien/steem-script-an-open-json-standard-for-trusted-workflows-proposal).