### PR TITLE
Add missing leftContainer display property

### DIFF
--- a/src/styles/modules/feed-layout.less
+++ b/src/styles/modules/feed-layout.less
@@ -17,6 +17,7 @@
 
   .leftContainer {
     float: left;
+    display: none;
     width: @left-width;
 
     @media @medium {


### PR DESCRIPTION
There was missing `display` property on `leftContainer` and it didn't disappear on smaller screens ([reference](https://busy5-pr-506.herokuapp.com/)).