### PR TITLE
Check if containers are not undefined

### DIFF
--- a/src/components/Utils/Affix.js
+++ b/src/components/Utils/Affix.js
@@ -56,7 +56,7 @@ class Affix extends React.Component {
   }
 
   handleScroll = () => {
-    if (!this.relativeContainer || !this.affixContainer) {
+    if (!this.relativeContainer || !this.affixContainer || !this.relativeContainer.offsetParent) {
       return;
     }
 

--- a/src/components/Utils/Affix.js
+++ b/src/components/Utils/Affix.js
@@ -56,6 +56,10 @@ class Affix extends React.Component {
   }
 
   handleScroll = () => {
+    if (!this.relativeContainer || !this.affixContainer) {
+      return;
+    }
+
     const { stickPosition } = this.props;
 
     const windowHeight = document.body.clientHeight;


### PR DESCRIPTION
When sidebars have `display: none` property containers are `undefined` causing Affix to throw errors ([reference](https://busy5-pr-506.herokuapp.com/))