### PR TITLE
Fix loading new posts

### DIFF
--- a/src/post/postSingle/PostSingle.js
+++ b/src/post/postSingle/PostSingle.js
@@ -19,6 +19,7 @@ import { jsonParse } from '../../helpers/formatter';
 import StoryFull from '../../components/Story/StoryFull';
 import { RightSidebar } from '../../app/Sidebar/index';
 import Affix from '../../components/Utils/Affix';
+import ScrollToTop from '../../components/Utils/ScrollToTop';
 
 // reblogList: reblog,
 // bookmarks,
@@ -201,6 +202,7 @@ export default class PostSingle extends Component {
             content={image || 'https://steemit.com/images/steemit-twshare.png'}
           />
         </Helmet>
+        <ScrollToTop />
         <div className="shifted">
           <div className="post-layout container">
             <Affix className="rightContainer" stickPosition={77}>

--- a/src/post/postSingle/PostSingle.js
+++ b/src/post/postSingle/PostSingle.js
@@ -34,6 +34,7 @@ import ScrollToTop from '../../components/Utils/ScrollToTop';
 @connect(
   ({ posts, app, reblog, auth, bookmarks }) => ({
     content: posts[app.lastPostId] || null,
+    loading: posts.postLoading,
     lastPostId: app.lastPostId,
     reblogList: reblog,
     bookmarks,
@@ -95,7 +96,7 @@ export default class PostSingle extends Component {
 
   render() {
     // let onEdit;
-    const { content, auth, reblogList, bookmarks, votePost, reblog, toggleBookmark } = this.props;
+    const { content, loading, auth, reblogList, bookmarks, votePost, reblog, toggleBookmark } = this.props;
 
     if (!content || !content.author) {
       return <div className="main-panel"><Loading /></div>;
@@ -211,16 +212,19 @@ export default class PostSingle extends Component {
               </div>
             </Affix>
             <div className="center">
-              <StoryFull
-                post={content}
-                postState={postState}
-                onFollowClick={() => console.log('Follow click')}
-                onSaveClick={() => toggleBookmark(content.id)}
-                onReportClick={reportPost}
-                onLikeClick={likePost}
-                onCommentClick={() => console.log('Comment click')}
-                onShareClick={() => reblog(content.id)}
-              />
+              {
+                (loading) ? <Loading /> :
+                <StoryFull
+                  post={content}
+                  postState={postState}
+                  onFollowClick={() => console.log('Follow click')}
+                  onSaveClick={() => toggleBookmark(content.id)}
+                  onReportClick={reportPost}
+                  onLikeClick={likePost}
+                  onCommentClick={() => console.log('Comment click')}
+                  onShareClick={() => reblog(content.id)}
+                />
+              }
             </div>
           </div>
           {/* {content.author && !modal &&

--- a/src/post/postSingle/PostSingle.js
+++ b/src/post/postSingle/PostSingle.js
@@ -73,10 +73,7 @@ export default class PostSingle extends Component {
   // };
 
   componentWillMount() {
-    const { content } = this.props;
-    if (!content) {
-      this.props.getContent();
-    }
+    this.props.getContent();
   }
   // componentDidMount() {
   //   const { modal } = this.props;

--- a/src/post/postsReducers.js
+++ b/src/post/postsReducers.js
@@ -47,7 +47,11 @@ const postItem = (state = {}, action) => {
   }
 };
 
-const posts = (state = {}, action) => {
+const initialState = {
+  postLoading: false,
+};
+
+const posts = (state = initialState, action) => {
   let posts = {};
   switch (action.type) {
     case feedTypes.GET_FEED_CONTENT_SUCCESS:
@@ -71,13 +75,24 @@ const posts = (state = {}, action) => {
         ...state,
         ...posts,
       };
+    case postsActions.GET_CONTENT_START:
+      return {
+        ...state,
+        postLoading: true,
+      };
     case postsActions.GET_CONTENT_SUCCESS:
       return {
         ...state,
+        postLoading: false,
         [action.payload.id]: {
           ...state[action.payload.id],
           ...action.payload,
         },
+      };
+    case postsActions.GET_CONTENT_ERROR:
+      return {
+        ...state,
+        postLoading: false,
       };
     case postsActions.LIKE_POST_START:
       return {


### PR DESCRIPTION
This PR fixes the issue with loading new posts (earlier it wasn't reloading new posts, displaying same post over and over again).
It adds `postLoading` to `posts` state to display `Loading` component as well.