### PR TITLE
Ignore scrollbar width

### DIFF
--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -21,7 +21,7 @@
   src: url('../fonts/WhitneyBold.woff') format('woff')
 }
 
-html {
+body {
   overflow-y: scroll;
 }
 

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -21,6 +21,10 @@
   src: url('../fonts/WhitneyBold.woff') format('woff')
 }
 
+html {
+  overflow-y: scroll;
+}
+
 .white-bg {
   background: @white;
 }


### PR DESCRIPTION
Currently when moving to pages with different layout or when opening modals content moves around because of sidebar width.
This PR gets rid of this problem.