### PR TITLE
Rollback webpack-dev-server to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "jest": "^20.0.4",
     "react-test-renderer": "^15.6.1",
     "redux-mock-store": "^1.2.3",
-    "webpack-dev-server": "^2.5.1",
+    "webpack-dev-server": "~2.6.1",
     "webpack-hot-middleware": "^2.18.0"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,7 +4613,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip@^1.1.0, ip@^1.1.5:
+ip@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
@@ -9580,9 +9580,9 @@ webpack-dev-middleware@^1.10.2, webpack-dev-middleware@^1.11.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@^2.5.1:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.7.0.tgz#a0cbc99b275e5da1e2e57469af4d86e07c09e4f1"
+webpack-dev-server@~2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.6.1.tgz#0b292a9da96daf80a65988f69f87b4166e5defe7"
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"
@@ -9594,7 +9594,6 @@ webpack-dev-server@^2.5.1:
     html-entities "^1.2.0"
     http-proxy-middleware "~0.17.4"
     internal-ip "^1.2.0"
-    ip "^1.1.5"
     loglevel "^1.4.1"
     opn "4.0.2"
     portfinder "^1.0.9"


### PR DESCRIPTION
`webpack-dev-server` 2.7.0 got unpublished for some reason.