### PR TITLE
Add voting power slider to single post view

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,5 +3,8 @@
     "author": "siol",
     "parent_permlink": "test",
     "permlink": "translations"
+  },
+  "constants": {
+    "LIKE_BAR_MIN_POWER": 125
   }
 }

--- a/src/app/Menu/MenuPost.js
+++ b/src/app/Menu/MenuPost.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import numeral from 'numeral';
 import { FormattedMessage } from 'react-intl';
+import Slider from 'rc-slider';
 import { Link } from 'react-router';
 import { SimpleTooltipOrigin } from '../../widgets/tooltip/SimpleTooltip';
 import { getUpvotes, getDownvotes, sortVotes } from '../../helpers/voteHelpers';
@@ -19,6 +20,12 @@ const MenuPost = ({
   dislikePost,
   content,
   onEdit,
+  user,
+  updateVotePowerBar,
+  showVoteBar,
+  hideVoteBar,
+  voteBarEnabled,
+  showingVoteBar
 }) => {
   const pendingPayoutValue = parseFloat(content.pending_payout_value);
   const totalPayoutValue = parseFloat(content.total_payout_value);
@@ -41,24 +48,35 @@ const MenuPost = ({
     .slice(0, 5);
   const dislikesTooltipMsg = fiveLastDownvotes.map(vote => `${vote.voter}\n`);
   if (dislikesTooltipMsg.length === 5) dislikesTooltipMsg.push('...');
+  const { votePower } = user;
 
   return (
     <div className="secondary-nav">
       <ul className="container text-left">
         <li>
-          <a
-            className={isPostLiked ? 'active' : ''}
-            onClick={isPostLiked ? unlikePost : likePost}
-          >
-            <Icon name="thumb_up" />
-          </a>
-          {' '}
-          <SimpleTooltipOrigin message={likesTooltipMsg}>
-            <a>{numberOfLikes}</a>
-          </SimpleTooltipOrigin>
-          <span className="hidden-xs">
-            {' '}<FormattedMessage id="likes" defaultMessage="Likes" />
-          </span>
+          <div className="LikeBar--container LikeBar--comment-view" onMouseLeave={hideVoteBar}>
+            {!isPostLiked && voteBarEnabled && showingVoteBar && <div className="LikeBar">
+              <span className="LikeBar--text">Power: {votePower}%</span>
+              <Slider
+                defaultValue={votePower} min={1} tipTransitionName="rc-slider-tooltip-zoom-down"
+                onChange={updateVotePowerBar}
+              />
+            </div>}
+            <a
+              className={isPostLiked ? 'active' : ''}
+              onClick={isPostLiked ? unlikePost : likePost.bind(null, votePower * 100)}
+              onMouseEnter={showVoteBar}
+            >
+              <Icon name="thumb_up" />
+            </a>
+            {' '}
+            <SimpleTooltipOrigin message={likesTooltipMsg}>
+              <a>{numberOfLikes}</a>
+            </SimpleTooltipOrigin>
+            <span className="hidden-xs">
+              {' '}<FormattedMessage id="likes" defaultMessage="Likes" />
+            </span>
+          </div>
         </li>
 
         <li>

--- a/src/auth/pushpadHelper.js
+++ b/src/auth/pushpadHelper.js
@@ -45,7 +45,7 @@ export const initPushpad = (username, token) => {
         }
 
         const { signatureId } = res;
-        
+
         pushpad('uid', `${username}`, signatureId);
         pushpad('subscribe', (isSubscribed) => {
           if (!isSubscribed) {
@@ -71,5 +71,5 @@ export const initPushpad = (username, token) => {
       });
   });
 
-  
+
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+const LIKE_BAR_MIN_POWER = 125;
+
+export default {
+  LIKE_BAR_MIN_POWER
+};

--- a/src/post/PostActionButtons.js
+++ b/src/post/PostActionButtons.js
@@ -9,7 +9,7 @@ import PayoutLabel from './actionButtons/PayoutLabel';
 import * as postActions from './postActions';
 import Icon from '../widgets/Icon';
 import ReblogButton from './actionButtons/ReblogButton';
-import Constants from '../constants';
+import config from '../../config';
 
 @connect(
   state => ({
@@ -87,7 +87,7 @@ export default class PostActionButtons extends Component {
         props.total_vesting_shares,
         props.total_vesting_fund_steem);
 
-    const likeBarEnabled = power > Constants.LIKE_BAR_MIN_POWER;
+    const likeBarEnabled = power > config.constants.LIKE_BAR_MIN_POWER;
     return (
       <ul>
         <li>

--- a/src/post/PostActionButtons.js
+++ b/src/post/PostActionButtons.js
@@ -9,8 +9,8 @@ import PayoutLabel from './actionButtons/PayoutLabel';
 import * as postActions from './postActions';
 import Icon from '../widgets/Icon';
 import ReblogButton from './actionButtons/ReblogButton';
+import Constants from '../constants';
 
-const LIKE_BAR_MIN_POWER = 125;
 @connect(
   state => ({
     app: state.app,
@@ -87,7 +87,7 @@ export default class PostActionButtons extends Component {
         props.total_vesting_shares,
         props.total_vesting_fund_steem);
 
-    const likeBarEnabled = power > LIKE_BAR_MIN_POWER;
+    const likeBarEnabled = power > Constants.LIKE_BAR_MIN_POWER;
     return (
       <ul>
         <li>

--- a/src/post/actionButtons/LikeButton.scss
+++ b/src/post/actionButtons/LikeButton.scss
@@ -1,7 +1,15 @@
 .LikeBar--container{
+  &.LikeBar--comment-view {
+    display: block;
+
+    .LikeBar {
+      left: -15%;
+    }
+  }
+
   position: relative;
   @media (min-width: 600px) {
-    display: flex; 
+    display: flex;
     justify-content: center;
   }
 }

--- a/src/post/postSingle/PostSingle.js
+++ b/src/post/postSingle/PostSingle.js
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 import { bindActionCreators } from 'redux';
 import sanitize from 'sanitize-html';
 import { formatter } from 'steem';
-import Constants from '../../constants';
+import config from '../../../config';
 
 import { getHtml } from '../Body';
 import * as postActions from './../postActions';
@@ -129,11 +129,13 @@ export default class PostSingle extends Component {
       content.active_votes.some(vote => vote.voter === auth.user.name && vote.percent < 0);
 
     const { app } = this.props;
+    const totalVestingShares = app.props ? app.props.total_vesting_shares : 0;
+    const totalVestingFundSteem = app.props ? app.props.total_vesting_fund_steem : 0;
 
-    const power = formatter.vestToSteem(auth.user.vesting_shares, app.props.total_vesting_shares,
-      app.props.total_vesting_fund_steem);
+    const power = formatter.vestToSteem(auth.user.vesting_shares, totalVestingShares,
+      totalVestingFundSteem);
 
-    const voteBarEnabled = power > Constants.LIKE_BAR_MIN_POWER;
+    const voteBarEnabled = power > config.constants.LIKE_BAR_MIN_POWER;
 
     const canReblog = auth.isAuthenticated && auth.user.name !== content.author;
 

--- a/src/post/postSingle/PostSingle.js
+++ b/src/post/postSingle/PostSingle.js
@@ -4,6 +4,8 @@ import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import { bindActionCreators } from 'redux';
 import sanitize from 'sanitize-html';
+import { formatter } from 'steem';
+import Constants from '../../constants';
 
 import { getHtml } from '../Body';
 import * as postActions from './../postActions';
@@ -17,6 +19,7 @@ import { editPost } from '../Write/EditorActions';
 import Loading from '../../widgets/Loading';
 import { jsonParse } from '../../helpers/formatter';
 
+
 @connect(
   ({ posts, app, reblog, auth, bookmarks }) => ({
     content: posts[app.lastPostId] || null,
@@ -25,6 +28,7 @@ import { jsonParse } from '../../helpers/formatter';
     reblogList: reblog,
     bookmarks,
     auth,
+    app
   }),
   (dispatch, ownProps) => bindActionCreators({
     reblog: reblogActions.reblog,
@@ -35,7 +39,7 @@ import { jsonParse } from '../../helpers/formatter';
     }),
     openCommentingDraft: commentsActions.openCommentingDraft,
     closeCommentingDraft: commentsActions.closeCommentingDraft,
-    likePost: id => postActions.votePost(id),
+    likePost: (id, power) => postActions.votePost(id, power),
     unlikePost: id => postActions.votePost(id, 0),
     dislikePost: id => postActions.votePost(id, -1000),
     toggleBookmark: bookmarkActions.toggleBookmark,
@@ -62,6 +66,8 @@ export default class PostSingle extends Component {
     modalResetScroll: () => null,
   };
 
+  state = { showingVoteBar: false }
+
   componentWillMount() {
     const { content } = this.props;
     if (!content) {
@@ -83,6 +89,14 @@ export default class PostSingle extends Component {
     if (process.env.IS_BROWSER) {
       global.document.title = 'Busy';
     }
+  }
+
+  showVoteBar = () => {
+    this.setState(() => ({ showingVoteBar: true }));
+  }
+
+  hideVoteBar = () => {
+    this.setState(() => ({ showingVoteBar: false }));
   }
 
   render() {
@@ -114,6 +128,13 @@ export default class PostSingle extends Component {
       content.active_votes &&
       content.active_votes.some(vote => vote.voter === auth.user.name && vote.percent < 0);
 
+    const { app } = this.props;
+
+    const power = formatter.vestToSteem(auth.user.vesting_shares, app.props.total_vesting_shares,
+      app.props.total_vesting_fund_steem);
+
+    const voteBarEnabled = power > Constants.LIKE_BAR_MIN_POWER;
+
     const canReblog = auth.isAuthenticated && auth.user.name !== content.author;
 
     const theProps = {
@@ -121,7 +142,7 @@ export default class PostSingle extends Component {
       reblog: () => reblog(content.id),
       isReblogged: reblogList.includes(content.id),
       canReblog,
-      likePost: () => this.props.likePost(content.id),
+      likePost: votePower => this.props.likePost(content.id, votePower),
       unlikePost: () => this.props.unlikePost(content.id),
       dislikePost: () => this.props.dislikePost(content.id),
       isPostLiked,
@@ -134,6 +155,10 @@ export default class PostSingle extends Component {
       prevStory,
       openPostModal: this.props.openPostModal,
       modalResetScroll: this.props.modalResetScroll,
+      showVoteBar: this.showVoteBar,
+      hideVoteBar: this.hideVoteBar,
+      voteBarEnabled,
+      showingVoteBar: this.state.showingVoteBar
     };
 
     const postMetaData = jsonParse(content.json_metadata);

--- a/src/post/postSingle/PostSingleContent.js
+++ b/src/post/postSingle/PostSingleContent.js
@@ -38,7 +38,13 @@ const PostSingleContent = ({
   isPostLiked,
   isPostDisliked,
   onEdit,
-  location
+  location,
+  user,
+  updateVotePowerBar,
+  showVoteBar,
+  hideVoteBar,
+  voteBarEnabled,
+  showingVoteBar
 }) => {
   const jsonMetadata = jsonParse(content.json_metadata);
   const hasAnchoredLink = !!location.hash;
@@ -91,6 +97,12 @@ const PostSingleContent = ({
         isPostDisliked={isPostDisliked}
         content={content}
         onEdit={onEdit}
+        user={user}
+        updateVotePowerBar={updateVotePowerBar}
+        showVoteBar={showVoteBar}
+        hideVoteBar={hideVoteBar}
+        voteBarEnabled={voteBarEnabled}
+        showingVoteBar={showingVoteBar}
       />
       <div className="container">
         <AuthorBio authorName={content.author} />

--- a/src/post/postSingle/PostSingleModal.js
+++ b/src/post/postSingle/PostSingleModal.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
+import { connect } from 'react-redux';
 import PostSingleContent from './PostSingleContent';
 import PostSingleComments from './PostSingleComments';
+import { updateVotePowerBar } from '../../user/userActions';
 import Icon from '../../widgets/Icon';
 import './PostSingleModal.scss';
 
@@ -37,6 +39,7 @@ const PrevButton = ({ content, onClick }) => (
   </div>
 );
 
+@connect(({ user }) => ({ user }), { updateVotePowerBar })
 export default class PostSingleModal extends Component {
 
   componentDidMount() {

--- a/src/post/postSingle/PostSinglePage.js
+++ b/src/post/postSingle/PostSinglePage.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PostSingleContent from './PostSingleContent';
 import PostSingleComments from './PostSingleComments';
+import { updateVotePowerBar } from '../../user/userActions';
 
+@connect(({ user }) => ({ user }), { updateVotePowerBar })
 export default class PostSinglePage extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
### What does this PR do?

It adds a voting power slider to the comment view when the `thumbs up` icon is hovered on

### How can I manually test this?

Open a post modal and hover on the thumbs up icon, a voting power slider will appear if the user has enough `steem` power.

### Image(s)

<img width="896" alt="screen shot 2017-08-15 at 7 19 59 pm" src="https://user-images.githubusercontent.com/7131935/29329836-18022b74-81ef-11e7-8a5f-087d205a9ad8.png">
