### PR TITLE
Remove PORT from DefinePlugin

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ function normalizePort(val) {
  * Get port from environment and store in Express.
  */
 
-const port = normalizePort(process.env.PORT);
+const port = normalizePort(process.env.PORT || 3000);
 app.set('port', port);
 
 /**

--- a/webpack/webpack.server.config.js
+++ b/webpack/webpack.server.config.js
@@ -93,7 +93,6 @@ module.exports = {
         STEEMCONNECT_IMG_HOST: JSON.stringify(process.env.STEEMCONNECT_IMG_HOST || 'https://img.steemconnect.com'),
         STEEMCONNECT_HOST: JSON.stringify(process.env.STEEMCONNECT_HOST || 'https://v2.steemconnect.com'),
         STEEMCONNECT_REDIRECT_URL: JSON.stringify(process.env.STEEMCONNECT_REDIRECT_URL || 'https://busy.org/callback'),
-        PORT: JSON.stringify(process.env.PORT || '3000'),
         WS: JSON.stringify(process.env.WS || 'wss://steemd-int.steemit.com'),
         IS_BROWSER: JSON.stringify(false),
       },


### PR DESCRIPTION
process.env.PORT is undefined at the time of compilation, so it
resolves to undefined. It removes PORT from DefinePlugin so it is
resolved at runtime, not compilation time