### PR TITLE
Add fix for editor that prevented new line and pasting content

### DIFF
--- a/src/post/Write/PostEditor.js
+++ b/src/post/Write/PostEditor.js
@@ -290,6 +290,8 @@ class PostEditor extends Component {
 
   render() {
     const { editorState } = this.state;
+    /* eslint-disable no-console */
+    console.log('render state', plugins);
 
     // If the user changes block type before entering any text, we can
     // either style the placeholder or hide it. Let's just hide it now.
@@ -320,7 +322,7 @@ class PostEditor extends Component {
             editorState={editorState}
             handleKeyCommand={this.handleKeyCommand}
             onChange={this.onChange}
-            plugins={plugins}
+            plugins={[plugins]}
           />
           <EmojiSuggestions />
           <DeleteImgBtn />

--- a/src/post/Write/PostEditor.js
+++ b/src/post/Write/PostEditor.js
@@ -290,8 +290,6 @@ class PostEditor extends Component {
 
   render() {
     const { editorState } = this.state;
-    /* eslint-disable no-console */
-    console.log('render state', plugins);
 
     // If the user changes block type before entering any text, we can
     // either style the placeholder or hide it. Let's just hide it now.


### PR DESCRIPTION
### What does this PR do?

It fixes the issue with the editor that prevented new lines and pasted content from being entered into the editor.

### Relevant trello link

https://trello.com/c/YC85uslJ/7-fix-issue-with-editor-cant-copy-past-or-make-new-line

### How to manually test

Open the page to add a new post, you should be able to paste content into the editor as well as enter new lines which was previously causing an error to be thrown in the console.