### PR TITLE
Fix user comments and hide reblog action for some posts

### DIFF
--- a/src/comments/commentsReducer.js
+++ b/src/comments/commentsReducer.js
@@ -159,14 +159,14 @@ const commentItem = (state = {}, action) => {
 const commentsData = (state = {}, action) => {
   switch (action.type) {
     case commentsTypes.GET_COMMENTS_SUCCESS:
-    case userTypes.GET_USER_COMMENTS_SUCCESS:
       return {
         ...state,
         ...mapCommentsBasedOnId(action.payload.content),
       };
+    case userTypes.GET_USER_COMMENTS_SUCCESS:
     case userTypes.GET_MORE_USER_COMMENTS_SUCCESS: {
       const commentsMoreList = {};
-      action.payload.result.forEach((comment) => {
+      action.payload.forEach((comment) => {
         commentsMoreList[comment.id] = comment;
       });
       return {

--- a/src/components/Story/StoryFooter.js
+++ b/src/components/Story/StoryFooter.js
@@ -160,13 +160,13 @@ class StoryFooter extends React.Component {
         <span className="StoryFooter__number">
           {commentsValue}
         </span>
-        <Tooltip
+        {post.parent_author === '' && <Tooltip
           title={postState.isReblogged ? 'You already reblogged this post' : 'Reblog'}
         >
           <a role="presentation" className={rebloggedClass} onClick={this.handleShareClick}>
             <i className="iconfont icon-send StoryFooter__share" />
           </a>
-        </Tooltip>
+        </Tooltip>}
         {!postState.isReblogged &&
           <Modal
             title="Reblog this post?"

--- a/src/feed/feedReducer.js
+++ b/src/feed/feedReducer.js
@@ -27,6 +27,7 @@ const feedFetching = (state = false, action) => {
     case userTypes.GET_USER_REPLIES_SUCCESS:
     case userTypes.GET_MORE_USER_REPLIES_SUCCESS:
     case userTypes.GET_USER_COMMENTS_SUCCESS:
+    case userTypes.GET_MORE_USER_COMMENTS_SUCCESS:
       return false;
     case feedTypes.GET_FEED_CONTENT:
     case feedTypes.GET_MORE_FEED_CONTENT:
@@ -36,6 +37,7 @@ const feedFetching = (state = false, action) => {
     case userTypes.GET_USER_REPLIES_START:
     case userTypes.GET_MORE_USER_REPLIES_START:
     case userTypes.GET_USER_COMMENTS_START:
+    case userTypes.GET_MORE_USER_COMMENTS_START:
       return true;
     default:
       return state;
@@ -61,9 +63,11 @@ const feedIdsList = (state = [], action) => {
       return state;
     }
     case userTypes.GET_USER_COMMENTS_SUCCESS:
-      return Object.keys(action.payload.content).map(key => action.payload.content[key].id);
+      return [...state, ...action.payload.map(comment => comment.id)];
     case userTypes.GET_MORE_USER_COMMENTS_SUCCESS:
-      return action.payload.result.map(comment => comment.id);
+      // remove last element from current state because we used it as start_permlink
+      // for pagination
+      return [...state.slice(0, state.length - 1), ...action.payload.map(comment => comment.id)];
     case userTypes.GET_USER_REPLIES_SUCCESS:
       return Object.keys(action.payload).reverse();
     case userTypes.GET_MORE_USER_REPLIES_SUCCESS:


### PR DESCRIPTION
- Update `getUserComments` action and its handlers to use `getDiscussionsByComments`.
- Fix `getMoreUserComments` and its handlers to load new comments properly.
- Display reblog button only if `post.parent_author === ''`.

**Related Trello task:** https://trello.com/c/fhgps3KV/106-page-username-comments-pagination