### PR TITLE
Add preload to post loading

### DIFF
--- a/src/app/Reblog/reblogActions.js
+++ b/src/app/Reblog/reblogActions.js
@@ -24,7 +24,7 @@ const storePostId = (postId) => {
 export const reblog = postId => (dispatch, getState) => {
   dispatch(startReblogging(postId));
   const { auth, posts } = getState();
-  const post = posts[postId];
+  const post = posts.list[postId];
 
   // if (!auth.isAuthenticated) {
   //  dispatch(notify('You are not logged in', 'error'));

--- a/src/app/appReducer.js
+++ b/src/app/appReducer.js
@@ -7,7 +7,6 @@ const initialState = {
   errorMessage: '',
   locale: 'auto',
   rate: 0,
-  lastPostId: undefined,
 };
 
 export default (state = initialState, action) => {
@@ -81,7 +80,6 @@ export default (state = initialState, action) => {
         ...state,
         isFetching: false,
         isLoaded: true,
-        lastPostId: action.payload ? action.payload.id : null,
       };
     default:
       return state;
@@ -90,4 +88,3 @@ export default (state = initialState, action) => {
 
 export const getLocale = state => state.locale;
 export const getRate = state => state.rate;
-export const getLastPostId = state => state.lastPostId;

--- a/src/comments/commentsActions.js
+++ b/src/comments/commentsActions.js
@@ -67,7 +67,7 @@ export const getComments = (postId, isFromAnotherComment = false) =>
     if (isFromAnotherComment) {
       content = comments.comments[postId];
     } else {
-      content = posts[postId];
+      content = posts.list[postId];
     }
 
     const { category, author, permlink } = content;

--- a/src/feed/feedActions.js
+++ b/src/feed/feedActions.js
@@ -122,7 +122,8 @@ export const getMoreFeedContent = ({ sortBy, category, limit }) => (
   getState,
   { steemAPI },
 ) => {
-  const feedContent = getFeedContentFromState(sortBy, category, getState().feed, getState().posts);
+  const feedContent =
+    getFeedContentFromState(sortBy, category, getState().feed, getState().posts.list);
   const isLoading = getFeedLoadingFromState(sortBy, category, getState().feed);
 
   if (!feedContent.length || isLoading) {
@@ -183,7 +184,7 @@ export const getMoreUserFeedContent = ({ username, limit }) => (
 ) => {
   const sortBy = 'feed';
   const { feed, posts } = getState();
-  const feedContent = getUserFeedContentFromState(username, feed, posts);
+  const feedContent = getUserFeedContentFromState(username, feed, posts.list);
   const isLoading = getUserFeedLoadingFromState(username, feed);
 
   if (!feedContent.length || isLoading) {

--- a/src/post/Post.js
+++ b/src/post/Post.js
@@ -11,7 +11,6 @@ import VisibilitySensor from 'react-visibility-sensor';
 import {
   getAuthenticatedUser,
   getPostContent,
-  getIsPostLoading,
   getBookmarks,
   getPendingLikes,
   getRebloggedList,
@@ -35,10 +34,9 @@ import ScrollToTopOnMount from '../components/Utils/ScrollToTopOnMount';
 
 @withRouter
 @connect(
-  state => ({
+  (state, ownProps) => ({
     user: getAuthenticatedUser(state),
-    content: getPostContent(state),
-    loading: getIsPostLoading(state),
+    content: getPostContent(state, ownProps.match.params.author, ownProps.match.params.permlink),
     bookmarks: getBookmarks(state),
     pendingLikes: getPendingLikes(state),
     reblogList: getRebloggedList(state),
@@ -68,7 +66,6 @@ export default class Post extends React.Component {
   static propTypes = {
     user: PropTypes.shape().isRequired,
     content: PropTypes.shape(),
-    loading: PropTypes.bool.isRequired,
     pendingLikes: PropTypes.arrayOf(PropTypes.number),
     reblogList: PropTypes.arrayOf(PropTypes.number),
     pendingReblogs: PropTypes.arrayOf(PropTypes.number),
@@ -106,7 +103,11 @@ export default class Post extends React.Component {
   };
 
   componentWillMount() {
-    this.props.getContent();
+    const { content } = this.props;
+
+    if (!content) {
+      this.props.getContent();
+    }
   }
 
   componentDidUpdate() {
@@ -147,7 +148,6 @@ export default class Post extends React.Component {
     const {
       user,
       content,
-      loading,
       pendingLikes,
       reblogList,
       pendingReblogs,
@@ -159,7 +159,7 @@ export default class Post extends React.Component {
       toggleBookmark,
     } = this.props;
 
-    if (this.props.loading || !content) {
+    if (!content) {
       return (
         <div className="main-panel">
           <Loading />
@@ -239,20 +239,18 @@ export default class Post extends React.Component {
               </div>
             </Affix>
             <div className="center" style={{ paddingBottom: '24px' }}>
-              {loading
-                ? <Loading />
-                : <StoryFull
-                  post={content}
-                  postState={postState}
-                  commentCount={content.children}
-                  pendingLike={pendingLikes.includes(content.id)}
-                  pendingFollow={pendingFollows.includes(content.author)}
-                  onFollowClick={this.handleFollowClick}
-                  onSaveClick={() => toggleBookmark(content.id, content.author, content.permlink)}
-                  onReportClick={reportPost}
-                  onLikeClick={likePost}
-                  onShareClick={() => reblog(content.id)}
-                />}
+              <StoryFull
+                post={content}
+                postState={postState}
+                commentCount={content.children}
+                pendingLike={pendingLikes.includes(content.id)}
+                pendingFollow={pendingFollows.includes(content.author)}
+                onFollowClick={this.handleFollowClick}
+                onSaveClick={() => toggleBookmark(content.id, content.author, content.permlink)}
+                onReportClick={reportPost}
+                onLikeClick={likePost}
+                onShareClick={() => reblog(content.id)}
+              />
               <VisibilitySensor onChange={this.handleCommentsVisibility} />
               <div id="comments" />
               <Comments show={this.state.commentsVisible} post={content} />

--- a/src/post/postActions.js
+++ b/src/post/postActions.js
@@ -46,7 +46,7 @@ export const votePost = (postId, author, permlink, weight = 10000) => (dispatch,
     type: LIKE_POST,
     payload: {
       promise: steemConnect
-        .vote(voter, posts[postId].author, posts[postId].permlink, weight)
+        .vote(voter, posts.list[postId].author, posts.list[postId].permlink, weight)
         .then((res) => {
           ReactGA.event({
             category: 'vote',
@@ -59,8 +59,8 @@ export const votePost = (postId, author, permlink, weight = 10000) => (dispatch,
             () =>
               dispatch(
                 getContent({
-                  author: posts[postId].author,
-                  permlink: posts[postId].permlink,
+                  author: posts.list[postId].author,
+                  permlink: posts.list[postId].permlink,
                   afterLike: true,
                 }),
               ),

--- a/src/post/postsReducer.js
+++ b/src/post/postsReducer.js
@@ -2,7 +2,6 @@ import * as feedTypes from '../feed/feedActions';
 import * as bookmarksActions from '../bookmarks/bookmarksActions';
 import * as postsActions from './postActions';
 import * as commentsActions from '../comments/commentsActions';
-import * as userActions from '../user/userActions';
 
 const postItem = (state = {}, action) => {
   switch (action.type) {
@@ -21,9 +20,8 @@ const postItem = (state = {}, action) => {
 };
 
 const initialState = {
-  lastPostId: null,
-  postLoading: false,
   pendingLikes: [],
+  list: {},
 };
 
 const posts = (state = initialState, action) => {
@@ -37,53 +35,34 @@ const posts = (state = initialState, action) => {
       action.payload.postsData.forEach((post) => { postsTemp[post.id] = post; });
       return {
         ...state,
-        ...postsTemp,
-      };
-    case userActions.GET_USER_REPLIES_SUCCESS:
-      return {
-        ...state,
-        ...action.payload,
-      };
-    case userActions.GET_MORE_USER_REPLIES_SUCCESS:
-      action.payload.forEach((post) => { posts[post.id] = post; });
-      return {
-        ...state,
-        ...posts,
-      };
-    case postsActions.GET_CONTENT_START:
-      if (action.meta.afterLike) {
-        return state;
-      }
-      return {
-        ...state,
-        postLoading: true,
+        list: {
+          ...state.list,
+          ...postsTemp,
+        },
       };
     case postsActions.GET_CONTENT_SUCCESS:
       if (action.meta.afterLike) {
         return {
           ...state,
-          lastPostId: action.payload.id,
-          postLoading: false,
           pendingLikes: state.pendingLikes.filter(post => post !== action.payload.id),
-          [action.payload.id]: {
-            ...state[action.payload.id],
-            ...action.payload,
+          list: {
+            ...state.list,
+            [action.payload.id]: {
+              ...state[action.payload.id],
+              ...action.payload,
+            },
           },
         };
       }
       return {
         ...state,
-        lastPostId: action.payload.id,
-        postLoading: false,
-        [action.payload.id]: {
-          ...state[action.payload.id],
-          ...action.payload,
+        list: {
+          ...state.list,
+          [action.payload.id]: {
+            ...state[action.payload.id],
+            ...action.payload,
+          },
         },
-      };
-    case postsActions.GET_CONTENT_ERROR:
-      return {
-        ...state,
-        postLoading: false,
       };
     case postsActions.LIKE_POST_START:
       return {
@@ -110,7 +89,11 @@ const posts = (state = initialState, action) => {
 
 export default posts;
 
-export const getPosts = state => state;
-export const getPostContent = state => state[state.lastPostId];
-export const getIsPostLoading = state => state.postLoading;
+export const getPosts = state => state.list;
+export const getPostContent = (state, author, permlink) =>
+  Object.values(state.list)
+    .find(post =>
+      post.author === author &&
+      post.permlink === permlink,
+    );
 export const getPendingLikes = state => state.pendingLikes;

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -44,8 +44,8 @@ export const getAuthenticatedUser = state => fromAuth.getAuthenticatedUser(state
 export const getAuthenticatedUserName = state => fromAuth.getAuthenticatedUserName(state.auth);
 
 export const getPosts = state => fromPosts.getPosts(state.posts);
-export const getPostContent = state => fromPosts.getPostContent(state.posts);
-export const getIsPostLoading = state => fromPosts.getIsPostLoading(state.posts);
+export const getPostContent = (state, author, permlink) =>
+  fromPosts.getPostContent(state.posts, author, permlink);
 export const getPendingLikes = state => fromPosts.getPendingLikes(state.posts);
 
 export const getDraftPosts = state => fromEditor.getDraftPosts(state.editor);
@@ -53,7 +53,6 @@ export const getIsEditorLoading = state => fromEditor.getIsEditorLoading(state.e
 
 export const getLocale = state => fromApp.getLocale(state.app);
 export const getRate = state => fromApp.getRate(state.app);
-export const getLastPostId = state => fromApp.getLastPostId(state.app);
 
 export const getFeed = state => fromFeed.getFeed(state.feed);
 

--- a/src/user/userActions.js
+++ b/src/user/userActions.js
@@ -229,8 +229,8 @@ export const getMoreUserReplies = username => (dispatch, getState, { steemAPI })
     return Promise.reject('lastFetchedReplyId not found');
   }
 
-  const startAuthor = posts[lastFetchedReplyId].author;
-  const startPermlink = posts[lastFetchedReplyId].permlink;
+  const startAuthor = posts.list[lastFetchedReplyId].author;
+  const startPermlink = posts.list[lastFetchedReplyId].permlink;
   const limit = 10;
 
   return dispatch({


### PR DESCRIPTION
If user opens post from feed it uses loaded data from feed instead of loading it again.

https://trello.com/c/48Bm1chr/111-single-post-remove-loading-if-previous-page-is-feed