### PR TITLE
Refactor sidebars and add logic to determine if user is on news page

### DIFF
--- a/src/app/Sidebar/LeftSidebar.js
+++ b/src/app/Sidebar/LeftSidebar.js
@@ -1,131 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { injectIntl, FormattedMessage } from 'react-intl';
-import { connect } from 'react-redux';
-import _ from 'lodash';
 import { Route, Switch } from 'react-router-dom';
-import urlParse from 'url-parse';
 
-import { openTransfer } from '../../wallet/walletActions';
-import { getAuthenticatedUser } from '../../reducers';
+import UserInfo from './UserInfo';
+import Navigation from './Navigation';
 
-import api from '../../steemAPI';
-import Topics from '../../components/Sidebar/Topics';
-import Sidenav from '../../components/Navigation/Sidenav';
-import Action from '../../components/Button/Action';
+const LeftSidebar = () => (
+  <Switch>
+    <Route path="/@:name" component={UserInfo} />
+    <Route path="/" component={Navigation} />
+  </Switch>
+);
 
-class SidebarWithTopics extends React.PureComponent {
-  state = {
-    isFetching: true,
-    isLoaded: false,
-    categories: [],
-    props: {},
-    menu: 'categories',
-  };
-
-  componentWillMount() {
-    api.getState('trending/busy', (err, result) => {
-      let categories =
-        (result.category_idx && result.category_idx.trending) ||
-        (result.tag_idx && result.tag_idx.trending);
-      categories = categories.filter(Boolean);
-      this.setState({
-        isFetching: false,
-        isLoaded: true,
-        categories,
-        props: result.props,
-      });
-    });
-  }
-
-  render() {
-    return <Topics topics={this.state.categories} />;
-  }
-}
-
-const LeftSidebar = injectIntl(({ authenticatedUser, user, intl, ...props }) => {
-  const location = user && _.get(user.json_metadata, 'profile.location');
-  let website = user && _.get(user.json_metadata, 'profile.website');
-
-  if (website && website.indexOf('http://') === -1 && website.indexOf('https://') === -1) {
-    website = `http://${website}`;
-  }
-  const url = urlParse(website);
-  let hostWithoutWWW = url.host;
-
-  if (hostWithoutWWW.indexOf('www.') === 0) {
-    hostWithoutWWW = hostWithoutWWW.slice(4);
-  }
-
-  return (<Switch>
-    <Route
-      path="/@:name"
-      render={() =>
-        (<div>
-          {user.name &&
-            <div>
-              {_.get(user && user.json_metadata, 'profile.about')}
-              <div style={{ marginTop: 16, marginBottom: 16, overflowWrap: 'break-word' }}>
-                {location && <div>
-                  <i className="iconfont icon-coordinates text-icon" />
-                  {location}
-                </div>}
-                {website && <div>
-                  <i className="iconfont icon-link text-icon" />
-                  <a target="_blank" rel="noopener noreferrer" href={website}>
-                    {`${hostWithoutWWW}${url.pathname.replace(/\/$/, '')}`}
-                  </a>
-                </div>}
-                <div>
-                  <i className="iconfont icon-time text-icon" />
-                  <FormattedMessage
-                    id="joined_date"
-                    defaultMessage="Joined {date}"
-                    values={{
-                      date: intl.formatDate(user.created, {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      }),
-                    }}
-                  />
-                </div>
-              </div>
-            </div>}
-          {user && <Action
-            style={{ margin: '5px 0' }}
-            text={intl.formatMessage({
-              id: 'transfer',
-              defaultMessage: 'Transfer',
-            })}
-            onClick={() => props.openTransfer(user.name)}
-          />}
-        </div>)}
-    />
-    <Route
-      path="/"
-      render={() =>
-        (<div>
-          <Sidenav username={authenticatedUser.name} />
-          <SidebarWithTopics />
-        </div>)}
-    />
-  </Switch>);
-});
-
-LeftSidebar.propTypes = {
-  authenticatedUser: PropTypes.shape().isRequired,
-  user: PropTypes.shape(),
-};
-
-LeftSidebar.defaultProps = {
-  user: undefined,
-};
-
-export default connect(
-  state => ({
-    authenticatedUser: getAuthenticatedUser(state),
-  }), {
-    openTransfer,
-  },
-)(LeftSidebar);
+export default LeftSidebar;

--- a/src/app/Sidebar/Navigation.js
+++ b/src/app/Sidebar/Navigation.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import api from '../../steemAPI';
+import { getAuthenticatedUser } from '../../reducers';
+
+import Topics from '../../components/Sidebar/Topics';
+import Sidenav from '../../components/Navigation/Sidenav';
+
+class SidebarWithTopics extends React.PureComponent {
+  state = {
+    isFetching: true,
+    isLoaded: false,
+    categories: [],
+    props: {},
+    menu: 'categories',
+  };
+
+  componentWillMount() {
+    api.getState('trending/busy', (err, result) => {
+      let categories =
+        (result.category_idx && result.category_idx.trending) ||
+        (result.tag_idx && result.tag_idx.trending);
+      categories = categories.filter(Boolean);
+      this.setState({
+        isFetching: false,
+        isLoaded: true,
+        categories,
+        props: result.props,
+      });
+    });
+  }
+
+  render() {
+    return <Topics topics={this.state.categories} />;
+  }
+}
+
+const Navigation = ({ authenticatedUser }) => (
+  <div>
+    <Sidenav username={authenticatedUser.name} />
+    <SidebarWithTopics />
+  </div>
+);
+
+Navigation.propTypes = {
+  authenticatedUser: PropTypes.shape().isRequired,
+};
+
+export default connect(
+  state => ({
+    authenticatedUser: getAuthenticatedUser(state),
+  }),
+)(Navigation);

--- a/src/app/Sidebar/RightSidebar.js
+++ b/src/app/Sidebar/RightSidebar.js
@@ -30,7 +30,7 @@ const InterestingPeopleWithData = () =>
 const RightSidebar = ({ authenticated, authenticatedUser }) =>
   (authenticated
     ? <Switch>
-      <Route path="/@:name" render={() => <InterestingPeopleWithData />} />
+      <Route path="/@:name" component={InterestingPeopleWithData} />
       <Route
         path="/"
         render={() =>

--- a/src/app/Sidebar/UserInfo.js
+++ b/src/app/Sidebar/UserInfo.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import _ from 'lodash';
+import urlParse from 'url-parse';
+
+import {
+  getUser,
+} from '../../reducers';
+import { openTransfer } from '../../wallet/walletActions';
+import Action from '../../components/Button/Action';
+
+const UserInfo = ({ intl, user, ...props }) => {
+  const location = user && _.get(user.json_metadata, 'profile.location');
+  let website = user && _.get(user.json_metadata, 'profile.website');
+
+  if (website && website.indexOf('http://') === -1 && website.indexOf('https://') === -1) {
+    website = `http://${website}`;
+  }
+  const url = urlParse(website);
+  let hostWithoutWWW = url.host;
+
+  if (hostWithoutWWW.indexOf('www.') === 0) {
+    hostWithoutWWW = hostWithoutWWW.slice(4);
+  }
+
+  return (<div>
+    {user.name &&
+      <div>
+        {_.get(user && user.json_metadata, 'profile.about')}
+        <div style={{ marginTop: 16, marginBottom: 16, overflowWrap: 'break-word' }}>
+          {location && <div>
+            <i className="iconfont icon-coordinates text-icon" />
+            {location}
+          </div>}
+          {website && <div>
+            <i className="iconfont icon-link text-icon" />
+            <a target="_blank" rel="noopener noreferrer" href={website}>
+              {`${hostWithoutWWW}${url.pathname.replace(/\/$/, '')}`}
+            </a>
+          </div>}
+          <div>
+            <i className="iconfont icon-time text-icon" />
+            <FormattedMessage
+              id="joined_date"
+              defaultMessage="Joined {date}"
+              values={{
+                date: intl.formatDate(user.created, {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                }),
+              }}
+            />
+          </div>
+        </div>
+      </div>}
+    {user && <Action
+      style={{ margin: '5px 0' }}
+      text={intl.formatMessage({
+        id: 'transfer',
+        defaultMessage: 'Transfer',
+      })}
+      onClick={() => props.openTransfer(user.name)}
+    />}
+  </div>);
+};
+
+UserInfo.propTypes = {
+  intl: PropTypes.shape().isRequired,
+  user: PropTypes.shape().isRequired,
+  openTransfer: PropTypes.func,
+};
+
+UserInfo.defaultProps = {
+  openTransfer: () => {},
+};
+
+export default connect(
+  (state, ownProps) => ({
+    user: getUser(state, ownProps.match.params.name),
+  }), { openTransfer })(injectIntl(UserInfo));

--- a/src/components/Navigation/Sidenav.js
+++ b/src/components/Navigation/Sidenav.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import './Sidenav.less';
 
+const isNews = (match, location) => location.pathname !== '/';
+
 const Sidenav = ({ username }) =>
   (<div>
     {username &&
@@ -21,7 +23,7 @@ const Sidenav = ({ username }) =>
           </NavLink>
         </li>
         <li>
-          <NavLink to="/trending" activeClassName="Sidenav__item--active">
+          <NavLink to="/trending" activeClassName="Sidenav__item--active" isActive={isNews}>
             <i className="iconfont icon-headlines" />
             <FormattedMessage id="news" defaultMessage="News" />
           </NavLink>

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -123,7 +123,7 @@ export default class User extends React.Component {
           <div className="feed-layout container">
             <Affix className="leftContainer" stickPosition={72}>
               <div className="left">
-                <LeftSidebar user={user} />
+                <LeftSidebar />
               </div>
             </Affix>
             <Affix className="rightContainer" stickPosition={72}>


### PR DESCRIPTION
Migrates from using `render` prop to `component` in `Route` to allow passing `match` down the tree (so makes it possible to add `isActive` logic).
Adds `isNews` to determine if `News` should be set to active.

https://trello.com/c/p2Y9zwpI/117-sidebar-left-feed-should-be-active-only-on-homepage-link-overwise-activate-news