### PR TITLE
Format comments count

### DIFF
--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -128,7 +128,7 @@ class StoryFull extends React.Component {
           <a href="#comments">
             <FormattedMessage
               id="comments_count"
-              values={{ count: commentCount }}
+              values={{ count: intl.formatNumber(commentCount) }}
               defaultMessage="{count} comments"
             />
           </a>


### PR DESCRIPTION
It prevents omitting count in `{count} comments` message.
https://trello.com/c/iVpBM69B/191-single-post-fix-label-0-comments