### PR TITLE
Resize textarea after inserting images and Markdown

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -119,7 +119,7 @@ class Editor extends React.Component {
     if (this.input) {
       this.input.value = post.body;
       this.renderMarkdown(this.input.value);
-      this.originalInput.resizeTextarea();
+      this.resizeTextarea();
     }
   };
 
@@ -149,6 +149,10 @@ class Editor extends React.Component {
 
     return values;
   };
+
+  resizeTextarea = () => {
+    if (this.originalInput) this.originalInput.resizeTextarea();
+  }
 
   //
   // Form validation and handling
@@ -264,6 +268,7 @@ class Editor extends React.Component {
       startPos,
     )}![${imageName}](${image})${this.input.value.substring(endPos, this.input.value.length)}`;
 
+    this.resizeTextarea();
     this.renderMarkdown(this.input.value);
     this.onUpdate();
   };
@@ -310,6 +315,7 @@ class Editor extends React.Component {
         break;
     }
 
+    this.resizeTextarea();
     this.renderMarkdown(this.input.value);
     this.onUpdate();
   };


### PR DESCRIPTION
`antd` resizes textarea on user input, but does not when value is changed in code.
This PR adds `resizeTextarea` method on `Editor` and triggers it when image or markdown code is inserted.

This issue on `CommentForm` will be solved in #703.

https://trello.com/c/Amfqay0I/175-editor-add-image-in-last-line-dont-trigger-the-autoresize