### PR TITLE
Focus comment after posting it

### DIFF
--- a/src/comments/commentsActions.js
+++ b/src/comments/commentsActions.js
@@ -46,8 +46,9 @@ const getCommentsChildrenLists = (apiRes) => {
  * @param {number} postId Id of post to fetch comments from
  * @param {boolean} reload If set to true isFetching won't be set to true
  * preventing loading icon to be dispalyed
+ * @param {object} focusedComment Object with author and permlink to which focus after loading
  */
-export const getComments = (postId, reload = false) =>
+export const getComments = (postId, reload = false, focusedComment = undefined) =>
   (dispatch, getState, { steemAPI }) => {
     const { posts } = getState();
 
@@ -67,6 +68,7 @@ export const getComments = (postId, reload = false) =>
       meta: {
         id: postId,
         reload,
+        focusedComment,
       },
     });
   };
@@ -102,9 +104,13 @@ export const sendComment = (parentPost, body) =>
           body,
           jsonMetadata,
         )
-          .then(() => {
+          .then((resp) => {
+            const focusedComment = {
+              author: resp.result.operations[0][1].author,
+              permlink: resp.result.operations[0][1].permlink,
+            };
             dispatch(notify('Comment submitted successfully', 'success'));
-            dispatch(getComments(rootComment, true));
+            dispatch(getComments(rootComment, true, focusedComment));
 
             if (window.ga) {
               window.ga('send', 'event', 'comment', 'submit', '', 5);

--- a/src/comments/commentsReducer.js
+++ b/src/comments/commentsReducer.js
@@ -20,10 +20,16 @@ const childrenById = (state = {}, action) => {
   }
 };
 
-const mapCommentsBasedOnId = (data) => {
+const mapCommentsBasedOnId = (data, action) => {
   const commentsList = {};
   Object.keys(data).forEach((key) => {
-    commentsList[data[key].id] = data[key];
+    const comment = data[key];
+    if (action.meta.reload
+      && comment.author === action.meta.focusedComment.author
+      && comment.permlink === action.meta.focusedComment.permlink) {
+      comment.focus = true;
+    }
+    commentsList[data[key].id] = comment;
   });
   return commentsList;
 };
@@ -33,7 +39,7 @@ const commentsData = (state = {}, action) => {
     case commentsTypes.GET_COMMENTS_SUCCESS:
       return {
         ...state,
-        ...mapCommentsBasedOnId(action.payload.content),
+        ...mapCommentsBasedOnId(action.payload.content, action),
       };
     case userTypes.GET_USER_COMMENTS_SUCCESS:
     case userTypes.GET_MORE_USER_COMMENTS_SUCCESS: {

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -58,6 +58,17 @@ class Comment extends React.Component {
     };
   }
 
+  componentDidMount() {
+    const { comment } = this.props;
+    if (comment.focus && this.self && window) {
+      this.self.scrollIntoView(false);
+    }
+  }
+
+  setSelf = (c) => {
+    this.self = c;
+  };
+
   handleShowReactions = () => this.setState({
     reactionsModalVisible: true,
   });
@@ -164,7 +175,7 @@ class Comment extends React.Component {
     const userDownVoted = userVote && userVote.percent < 0;
 
     return (
-      <div className="Comment">
+      <div ref={this.setSelf} className="Comment">
         <span
           role="presentation"
           className="Comment__visibility"

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -60,16 +60,20 @@ class Comment extends React.Component {
 
   componentDidMount() {
     const { comment } = this.props;
-    if (comment.focus && this.self && window) {
-      this.self.scrollIntoView(true);
-      document.body.scrollTop -= ((window.innerHeight / 2) - this.self.scrollHeight);
-      this.self.classList.add('Comment--focus');
-    }
+    if (comment.focus) this.focus();
   }
 
   setSelf = (c) => {
     this.self = c;
   };
+
+  focus = () => {
+    if (this.self && window) {
+      this.self.scrollIntoView(true);
+      document.body.scrollTop -= ((window.innerHeight / 2) - this.self.scrollHeight);
+      this.self.classList.add('Comment--focus');
+    }
+  }
 
   handleShowReactions = () => this.setState({
     reactionsModalVisible: true,

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -61,7 +61,8 @@ class Comment extends React.Component {
   componentDidMount() {
     const { comment } = this.props;
     if (comment.focus && this.self && window) {
-      this.self.scrollIntoView(false);
+      this.self.scrollIntoView(true);
+      document.body.scrollTop -= ((window.innerHeight / 2) - this.self.scrollHeight);
       this.self.classList.add('Comment--focus');
     }
   }

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -62,6 +62,7 @@ class Comment extends React.Component {
     const { comment } = this.props;
     if (comment.focus && this.self && window) {
       this.self.scrollIntoView(false);
+      this.self.classList.add('Comment--focus');
     }
   }
 

--- a/src/components/Comments/Comment.less
+++ b/src/components/Comments/Comment.less
@@ -1,9 +1,24 @@
 @import (reference) "../../styles/custom.less";
 
+@keyframes focus {
+  0%, 75% {
+    box-shadow: 4px 0 0px 0px #4757b2;
+  }
+
+  100% {
+    box-shadow: 4px 0 0px 0px transparent;
+  }
+}
+
 .Comment {
   position: relative;
   display: flex;
   margin-top: 16px;
+
+  &--focus {
+    animation-timing-function: ease-in-out;
+    animation: focus 3s 1;
+  }
 
   &__visibility {
     visibility: hidden;


### PR DESCRIPTION
This PR updates `getComments` action and related reducers to pass `focusedComment` to determine which comment should be focused. This adds `focus` method on `Comment` as well that will be used for focusing comments.

https://trello.com/c/7b72tP44/183-when-comment-success-focus-on-it