### PR TITLE
Hide topnav search on mobile and show logo and menu

### DIFF
--- a/src/styles/modules/topnav-layout.less
+++ b/src/styles/modules/topnav-layout.less
@@ -1,30 +1,32 @@
 .topnav-layout {
   .left {
-    display: none;
     position: absolute;
     width: @left-width;
+    margin-left: 16px;
 
-    @media @medium {
-      display: block;
+    @media @small {
+      margin-left: 0;
     }
   }
 
   .right {
-    display: none;
     position: absolute;
     top: 0;
     right: 0;
     width: @right-width;
+    margin-right: 16px;
 
     @media @small {
-      display: block;
-    }  
+      margin-right: 0;
+    }
   }
 
   .center {
+    display: none;
     width: 100%;
 
     @media @small {
+      display: block;
       width: calc(100% ~"-" (@right-width + @margin)); 
       margin-right: @right-width + @margin;
     }


### PR DESCRIPTION
This PR hide topnav search on mobile and show logo and menu. This help user to login on mobile, before it was not possible to do.
![image](https://user-images.githubusercontent.com/16245250/30204904-496482a0-94b1-11e7-8c36-7d549c27c5d6.png)
