### PR TITLE
Limit comment indentation on mobile

### DIFF
--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -343,7 +343,7 @@ class Comment extends React.Component {
             />}
           <div
             className={classNames('Comment__replies', {
-              'Comment__replies--no-indent': depth > 2,
+              'Comment__replies--no-indent': depth >= 2,
             })}
           >
             {!this.state.collapsed &&

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -338,7 +338,11 @@ class Comment extends React.Component {
               inputValue={this.state.commentFormText}
               onImageInserted={this.handleImageInserted}
             />}
-          <div className="Comment__replies">
+          <div
+            className={classNames('Comment__replies', {
+              'Comment__replies--no-indent': comment.depth > 2,
+            })}
+          >
             {!this.state.collapsed &&
               commentsChildren &&
               commentsChildren[comment.id] &&

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -31,6 +31,7 @@ class Comment extends React.Component {
       id: PropTypes.number,
       percent: PropTypes.number,
     })),
+    depth: PropTypes.number,
     onLikeClick: PropTypes.func,
     onDislikeClick: PropTypes.func,
     onSendComment: PropTypes.func,
@@ -42,6 +43,7 @@ class Comment extends React.Component {
     rootPostAuthor: undefined,
     commentsChildren: undefined,
     pendingVotes: [],
+    depth: 0,
     onLikeClick: () => {},
     onDislikeClick: () => {},
     onSendComment: () => {},
@@ -155,6 +157,7 @@ class Comment extends React.Component {
       rootPostAuthor,
       commentsChildren,
       pendingVotes,
+      depth,
     } = this.props;
 
     const pendingVote = find(pendingVotes, { id: comment.id });
@@ -340,7 +343,7 @@ class Comment extends React.Component {
             />}
           <div
             className={classNames('Comment__replies', {
-              'Comment__replies--no-indent': comment.depth > 2,
+              'Comment__replies--no-indent': depth > 2,
             })}
           >
             {!this.state.collapsed &&
@@ -349,6 +352,7 @@ class Comment extends React.Component {
               sortComments(commentsChildren[comment.id], sort).map(child =>
                 (<Comment
                   key={child.id}
+                  depth={depth + 1}
                   intl={this.props.intl}
                   authenticated={authenticated}
                   username={username}

--- a/src/components/Comments/Comment.less
+++ b/src/components/Comments/Comment.less
@@ -148,6 +148,11 @@
     }
   }
 
+  &__replies--no-indent {
+    position: relative;
+    left: -44px;
+  }
+
   &__icon_dislike:before {
     display: inline-block;
     transform: rotate(180deg);

--- a/src/components/Comments/Comment.less
+++ b/src/components/Comments/Comment.less
@@ -150,12 +150,10 @@
   }
 
   &__replies--no-indent {
-    position: relative;
-    left: -44px;
+    margin-left: -44px;
 
     @media @small {
-      position: static;
-      left: auto;
+      margin-left: 0;
     }
   }
 

--- a/src/components/Comments/Comment.less
+++ b/src/components/Comments/Comment.less
@@ -1,3 +1,4 @@
+@import (reference) "../../styles/modules/variables.less";
 @import (reference) "../../styles/custom.less";
 
 @keyframes focus {
@@ -151,6 +152,11 @@
   &__replies--no-indent {
     position: relative;
     left: -44px;
+
+    @media @small {
+      position: static;
+      left: auto;
+    }
   }
 
   &__icon_dislike:before {

--- a/src/components/Comments/Comments.js
+++ b/src/components/Comments/Comments.js
@@ -141,6 +141,7 @@ class Comments extends React.Component {
           sortComments(comments, sort).map(comment =>
             (<Comment
               key={comment.id}
+              depth={0}
               authenticated={authenticated}
               username={username}
               comment={comment}


### PR DESCRIPTION
- Adds `Comment__replies--no-indent` class.
- If `depth` (drawn, not logical from API) is higher or equal to 2 replies will stop indenting.
- Works for `@small` devices only.

https://trello.com/c/p21C3QGx/230-responsive-comment-intend-should-have-limit