### PR TITLE
Fix cover text visibility

### DIFF
--- a/src/components/UserHeader.js
+++ b/src/components/UserHeader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { Tag, Tooltip, Popover } from 'antd';
 import { formatter } from 'steem';
@@ -17,10 +18,11 @@ const UserHeader = ({
   userReputation,
   rank,
   isSameUser,
+  hasCover,
   onSelect,
 }) =>
   (<div
-    className="UserHeader"
+    className={classNames('UserHeader', { 'UserHeader--cover': hasCover })}
     style={{ backgroundImage: `url("${process.env.STEEMCONNECT_IMG_HOST}/@${handle}/cover")` }}
   >
     <div className="UserHeader__container">
@@ -82,6 +84,7 @@ UserHeader.propTypes = {
   ]),
   rank: PropTypes.string,
   isSameUser: PropTypes.bool,
+  hasCover: PropTypes.bool,
   onSelect: PropTypes.func,
 };
 
@@ -91,6 +94,7 @@ UserHeader.defaultProps = {
   userReputation: '0',
   rank: 'Minnow',
   isSameUser: false,
+  hasCover: false,
   onSelect: () => {},
 };
 

--- a/src/components/UserHeader.less
+++ b/src/components/UserHeader.less
@@ -15,6 +15,19 @@
       color: darken(@purple, 15%);
     }
   }
+
+  &--cover {
+    background-color: darken(@purple, 25%) !important;
+
+    .UserHeader__rank,
+    .UserHeader__rank & > i,
+    .UserHeader__handle,
+    .UserHeader__more,
+    .UserHeader__user__username  {
+      color: #FFFFFF !important;
+      text-shadow: 0 0 4px rgba(0, 0, 0, 0.8);
+    }
+  }
 }
 
 .UserHeader__container {
@@ -64,6 +77,7 @@
   .ant-tag {
     margin-left: 8px;
     vertical-align: 4px;
+    text-shadow: none;
   }
 }
 

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -80,6 +80,7 @@ export default class User extends React.Component {
     const canonicalUrl = `${busyHost}/@${username}`;
     const url = `${busyHost}/@${username}`;
     const displayedUsername = profile.name || username || '';
+    const hasCover = !!profile.cover_image;
     const title = `${displayedUsername} - Busy`;
 
     const isSameUser = authenticated && authenticatedUser.name === username;
@@ -116,6 +117,7 @@ export default class User extends React.Component {
             user={user}
             username={displayedUsername}
             isSameUser={isSameUser}
+            hasCover={hasCover}
             onFollowClick={this.handleFollowClick}
             onSelect={this.handleUserMenuSelect}
           />}

--- a/src/user/UserHero.js
+++ b/src/user/UserHero.js
@@ -35,6 +35,7 @@ const UserHero = ({
   user,
   username,
   isSameUser,
+  hasCover,
   onSelect,
 }) =>
   (<div>
@@ -52,6 +53,7 @@ const UserHero = ({
                   userReputation={user.reputation}
                   rank={getUserRank(user.vesting_shares)}
                   isSameUser={isSameUser}
+                  hasCover={hasCover}
                   onSelect={onSelect}
                 />
             }
@@ -70,11 +72,13 @@ UserHero.propTypes = {
   user: PropTypes.shape().isRequired,
   username: PropTypes.string.isRequired,
   isSameUser: PropTypes.bool,
+  hasCover: PropTypes.bool,
   onSelect: PropTypes.func,
 };
 
 UserHero.defaultProps = {
   isSameUser: false,
+  hasCover: false,
   onSelect: () => {},
 };
 


### PR DESCRIPTION
https://trello.com/c/tNRzZKi0/190-cover-picture-break-visibility

If an user have a cover image the text in UserHeader will be changed to white with text-shadow. If user dont have a cover color remain as usual.

![image](https://user-images.githubusercontent.com/16245250/30243564-4f54578c-95d6-11e7-81c7-5b55246c9de9.png)

Close #366 