### PR TITLE
Add image proxy helper

### DIFF
--- a/src/components/Story/StoryPreview.js
+++ b/src/components/Story/StoryPreview.js
@@ -14,19 +14,18 @@ import {
   isPostWithEmbedBeforeFirstHalf,
 } from './StoryHelper';
 import { getHtml } from './Body';
-
-const IMG_PROXY_PREFIX = '//res.cloudinary.com/hpiynhbhq/image/fetch/w_600,h_800,c_limit/';
+import { getProxyImageURL } from '../../helpers/image';
 
 const StoryPreview = ({ post }) => {
   const jsonMetadata = jsonParse(post.json_metadata);
   let imagePath = '';
 
   if (jsonMetadata.image && jsonMetadata.image[0]) {
-    imagePath = `${IMG_PROXY_PREFIX}${jsonMetadata.image[0]}`;
+    imagePath = getProxyImageURL(jsonMetadata.image[0], 'preview');
   } else {
     const bodyImg = post.body.match(image());
     if (bodyImg && bodyImg.length) {
-      imagePath = `${IMG_PROXY_PREFIX}${bodyImg[0]}`;
+      imagePath = getProxyImageURL(bodyImg[0], 'preview');
     }
   }
 
@@ -39,7 +38,7 @@ const StoryPreview = ({ post }) => {
       type: 'video',
       provider_name: 'DTube',
       embed: `<video controls="true" autoplay="true" src="https://ipfs.io/ipfs/${video.content.videohash}" poster="https://ipfs.io/ipfs/${video.info.snaphash}"><track kind="captions" /></video>`,
-      thumbnail: `${IMG_PROXY_PREFIX}https://ipfs.io/ipfs/${video.info.snaphash}`,
+      thumbnail: getProxyImageURL(`https://ipfs.io/ipfs/${video.info.snaphash}`, 'preview'),
     };
   }
 

--- a/src/helpers/image.js
+++ b/src/helpers/image.js
@@ -1,0 +1,14 @@
+const IMG_PROXY_PREFIX = '//res.cloudinary.com/hpiynhbhq/image/fetch/w_720,c_limit/';
+const IMG_PROXY_PREVIEW_PREFIX = '//res.cloudinary.com/hpiynhbhq/image/fetch/w_600,h_800,c_limit/';
+const IMG_PROXY_BACK = 'https://steemitimages.com/600x800/';
+
+export const getProxyImageURL = (url, type) => {
+  if (url.length > 256) {
+    return `${IMG_PROXY_BACK}${url}`;
+  } else if (type === 'preview') {
+    return `${IMG_PROXY_PREVIEW_PREFIX}${url}`;
+  }
+  return `${IMG_PROXY_PREFIX}${url}`;
+};
+
+export default null;

--- a/src/vendor/steemitHtmlReady.js
+++ b/src/vendor/steemitHtmlReady.js
@@ -8,13 +8,13 @@ import xmldom from 'xmldom';
 import embedjs from 'embedjs';
 import linksRe from './steemitLinks';
 import { validateAccountName } from './ChainValidation';
+import { getProxyImageURL } from '../helpers/image';
 
 const noop = () => {};
 const DOMParser = new xmldom.DOMParser({
   errorHandler: { warning: noop, error: noop },
 });
 const XMLSerializer = new xmldom.XMLSerializer();
-const IMG_PROXY_PREFIX = '//res.cloudinary.com/hpiynhbhq/image/fetch/w_720,c_limit/';
 
 /**
  * Functions performed by HTMLReady
@@ -171,12 +171,11 @@ function img(state, child) {
 
 // For all img elements with non-local URLs, prepend the proxy URL (e.g. `https://img0.steemit.com/0x0/`)
 function proxifyImages(doc) {
-  if (!IMG_PROXY_PREFIX) return;
   if (!doc) return;
   [...doc.getElementsByTagName('img')].forEach(node => {
     const url = node.getAttribute('src');
     if (!linksRe.local.test(url)) {
-      node.setAttribute('src', `${IMG_PROXY_PREFIX}${url}`);
+      node.setAttribute('src', getProxyImageURL(url));
     }
   });
 }


### PR DESCRIPTION
Some picture was failing due to a limitation from Cloudinary. The Cloudinary proxy image accept only image url with a maximum of 256 char. On this PR i switch to Steemit proxy image when url is longer than 256 char.

See: https://trello.com/c/t3paCZIc/199-busy-img-long-url-picture-fail-to-load

I've spoted another image that fail to load but not sure what is the reason, i created a new Trello card for it https://trello.com/c/ZSnnV6bG/265-busy-img-some-url-fail