### PR TITLE
Add wordBreak to UserInfo

### DIFF
--- a/src/app/Sidebar/UserInfo.js
+++ b/src/app/Sidebar/UserInfo.js
@@ -27,9 +27,9 @@ const UserInfo = ({ intl, user, ...props }) => {
 
   return (<div>
     {user.name &&
-      <div>
+      <div style={{ wordBreak: 'break-word' }}>
         {_.get(user && user.json_metadata, 'profile.about')}
-        <div style={{ marginTop: 16, marginBottom: 16, overflowWrap: 'break-word' }}>
+        <div style={{ marginTop: 16, marginBottom: 16 }}>
           {location && <div>
             <i className="iconfont icon-coordinates text-icon" />
             {location}


### PR DESCRIPTION
It fixes user bio not breaking properly.

![image](https://user-images.githubusercontent.com/1968722/30635850-04498444-9df4-11e7-9a92-cacb627ff01e.png)

https://trello.com/c/EswlWbJ3/262-user-profile-about-goes-out-of-the-frame
