### PR TITLE
Add clearfix

### DIFF
--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -111,4 +111,14 @@
     display: inline-block;
     vertical-align: middle;
   }
+
+  hr {
+    clear: both;
+  }
+
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }


### PR DESCRIPTION
This adds clearfix after `Body` and applies `clear: both` to `hr` as condenser does.

![image](https://user-images.githubusercontent.com/1968722/30639031-a0b6d896-9dfd-11e7-821c-25bd42d0157f.png)


https://trello.com/c/GXzS4HlW/260-single-post-render-bug