### PR TITLE
Style DTube videos

### DIFF
--- a/src/components/Story/PostFeedEmbed.less
+++ b/src/components/Story/PostFeedEmbed.less
@@ -22,7 +22,9 @@
   }
   
   &__preview {
-    width: 100% !important;
+    display: block;
+    max-width: 100%;
     max-height: 400px;
+    margin: 0 auto;
   }
 }

--- a/src/components/Story/PostFeedEmbed.less
+++ b/src/components/Story/PostFeedEmbed.less
@@ -23,5 +23,6 @@
   
   &__preview {
     width: 100% !important;
+    max-height: 400px;
   }
 }

--- a/src/components/Story/Story.less
+++ b/src/components/Story/Story.less
@@ -119,6 +119,11 @@
         color: #353535;
         text-decoration: none;
       }
+
+      video {
+        width: 100%;
+        max-height: 400px;
+      }
     }
 
     &__body {

--- a/src/components/Story/Story.less
+++ b/src/components/Story/Story.less
@@ -134,12 +134,10 @@
       width: 100%;
 
       & > img {
-        width: auto;
-        height: auto;
-        max-height: 400px;
-        max-width: 100%;
-        margin: 4px auto;
         display: block;
+        max-width: 100%;
+        max-height: 400px;
+        margin: 4px auto;
       }
     }
   }


### PR DESCRIPTION
This PR adds `max-height` to `400px` for embeds (same as for images) to prevent showing too long Stories in feed:
![image](https://user-images.githubusercontent.com/1968722/30641999-5278566c-9e09-11e7-95e1-7b97747a0db5.png)
`video` has been styled as well to prevent the same problem:
![image](https://user-images.githubusercontent.com/1968722/30642021-6b045f78-9e09-11e7-9d4f-a53e07358874.png)

https://trello.com/c/zMkJ44dw/258-add-max-height-to-dtube-thumb