### PR TITLE
Update styles to make Busy consistent with Condenser

### DIFF
--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -5,7 +5,10 @@
   font-family: @font-text;
   color: rgba(0, 0, 0, .8);
   line-height: 1.6em;
+  overflow-wrap: break-word;
   word-wrap: break-word;
+  word-break: break-word;
+  hyphens: none;
 
   &--full {
     font-size: 18px;
@@ -13,21 +16,76 @@
     @media @small {
       font-size: 21px;
     }
-
-    h1, h2, h3, h4, h5, h6 {
-      margin: 8px 0;
-      font-weight: 700;
-      line-height: 1.3em;
-    }
-
-    *:not(:empty):not(li):not(.pull-left):not(.pull-right) {
-      margin: 1.5rem 0;
-    }
   }
+
+  // Heading
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 700;
+  }
+
+  h1 {
+    margin: 2.5rem 0 .3rem;
+    font-size: 160%
+  }
+
+  h2 {
+    margin: 2.5rem 0 .3rem;
+    font-size: 140%;
+  }
+
+  h3 {
+    margin: 2rem 0 0.3rem;
+    font-size: 120%;
+  }
+
+  h4 {
+    margin: 1.5rem 0 0.2rem;
+    font-size: 110%;
+  }
+
+  h5 {
+    margin: 1rem 0 0.2rem;
+    font-size: 100%;
+  }
+
+  h6 {
+    margin: 1rem 0 0.2rem;
+    font-size: 90%;
+  }
+
+  // Paragraph
 
   p {
-    margin: 0.4rem 0;
+    font-size: 100%;
+    line-height: 150%;
+    margin: 0 0 1.5rem 0;
   }
+
+  // List
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol, ul {
+    margin-left: 20px;
+
+    li {
+      list-style-position: outside;
+      margin: 8px 0;
+
+      p {
+        display: inline;
+      }
+    }
+  }
+
+  // Quote and code
 
   blockquote {
     padding-left: 1rem;
@@ -54,6 +112,8 @@
     }
   }
 
+  // Table
+
   table {
     width: 100%;
     display: table;
@@ -77,15 +137,7 @@
     }
   }
 
-  ol {
-    list-style: decimal inside;
-  }
-
-  ul {
-    margin: 1rem 0;
-    margin-left: 2rem !important;
-    list-style: disc outside;
-  }
+  // Position
 
   div.pull-left {
     float: left;
@@ -98,6 +150,24 @@
     padding-left: 1rem;
     max-width: 50%;
   }
+
+  div.text-justify {
+    text-align: justify;
+  }
+
+  div.text-right {
+    text-align: right;
+  }
+
+  div.text-center {
+    text-align: center;
+  }
+
+  div.text-rtl {
+    direction: rtl;
+  }
+
+  // Images
 
   img {
     width: auto;

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -78,10 +78,6 @@
     li {
       list-style-position: outside;
       margin: 8px 0;
-
-      p {
-        display: inline;
-      }
     }
   }
 


### PR DESCRIPTION
This fixes issue with lists, clears `Body` styles and adds some functionality from Condenser (`.text-justify`, `.text-right`, `.text-center`, .text-rtl`).
![image](https://user-images.githubusercontent.com/1968722/30644769-cc9f0f08-9e13-11e7-8170-b7f4691b6fe0.png)

https://trello.com/c/JfAn2V0Z/269-list-number-bug-alignement