### PR TITLE
Add See All and image uploading notifications translations

### DIFF
--- a/src/components/Navigation/Notifications/Notifications.js
+++ b/src/components/Navigation/Notifications/Notifications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import NotificationFollowing from './NotificationFollowing';
 import NotificationReply from './NotificationReply';
 import NotificationTransfer from './NotificationTransfer';
@@ -54,7 +55,7 @@ const Notifications = ({ onClick, onSeeAllClick, notifications }) =>
     </div>
     <div className="Notifications__footer">
       <a role="presentation" onClick={onSeeAllClick}>
-        See All
+        <FormattedMessage id="see_all" defaultMessage="See All" />
       </a>
     </div>
   </div>);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,6 +22,7 @@
   "notification_mention_username_post":"{username} mentioned you on this post {post}.",
   "notification_reply_username_post":"{username} replied you on your {post}.",
   "notification_transfer_username_amount":"{username} sent you {amount}.",
+  "see_all":"See All",
   "discussions":"Discussions",
   "comments":"Comments",
   "comments_count":"{count} comments",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,8 @@
   "confirm":"Confirm",
   "continue":"Continue",
   "close":"Close",
+  "notify_uploading_image":"Uploading image",
+  "notify_uploading_iamge_error":"Couldn't upload image",
   "signup":"Sign up",
   "login":"Log in",
   "activity":"Activity",

--- a/src/post/Write/Write.js
+++ b/src/post/Write/Write.js
@@ -6,6 +6,7 @@ import kebabCase from 'lodash/kebabCase';
 import debounce from 'lodash/debounce';
 import isArray from 'lodash/isArray';
 import 'url-search-params-polyfill';
+import { injectIntl } from 'react-intl';
 import GetBoost from '../../components/Sidebar/GetBoost';
 
 import { getAuthenticatedUser, getDraftPosts, getIsEditorLoading, getIsEditorSaving } from '../../reducers';
@@ -17,6 +18,7 @@ import Affix from '../../components/Utils/Affix';
 
 const version = require('../../../package.json').version;
 
+@injectIntl
 @withRouter
 @connect(
   state => ({
@@ -34,6 +36,7 @@ const version = require('../../../package.json').version;
 )
 class Write extends React.Component {
   static propTypes = {
+    intl: PropTypes.shape().isRequired,
     user: PropTypes.shape().isRequired,
     draftPosts: PropTypes.shape().isRequired,
     loading: PropTypes.bool.isRequired,
@@ -189,7 +192,8 @@ class Write extends React.Component {
   };
 
   handleImageInserted = (blob, callback, errorCallback) => {
-    this.props.notify('Uploading image', 'info');
+    const { formatMessage } = this.props.intl;
+    this.props.notify(formatMessage({ id: 'notify_uploading_image', defaultMessage: 'Uploading image' }), 'info');
     const formData = new FormData();
     formData.append('files', blob);
 
@@ -201,7 +205,7 @@ class Write extends React.Component {
       .then(res => callback(res.secure_url, blob.name))
       .catch(() => {
         errorCallback();
-        this.props.notify("Couldn't upload image");
+        this.props.notify(formatMessage({ id: 'notify_uploading_iamge_error', defaultMessage: "Couldn't upload image" }));
       });
   };
 


### PR DESCRIPTION
This adds missing `See All` and image uploading notifications text.

We have notifications in action creators as well but it is impossible to use `react-intl` from there.
It's possible to use it statically like [this](https://github.com/yahoo/react-intl/issues/41#issuecomment-227268578), but it doesn't fit our code base (we would have to pass `intl` into `redux-thunk` when creating store, but we won't be able to create `IntlProvider` because we store locale in store. This won't allow changing language as well). We might want to migrate to platform agnostic API like [counterpart](https://github.com/martinandert/counterpart)  - same as Condenser. However, I don't think that's priority right now.

https://trello.com/c/FUq0MJgH/241-translate-see-all-and-uploading-image-and