### PR TITLE
Reload comments for parent post only

### DIFF
--- a/src/comments/commentsActions.js
+++ b/src/comments/commentsActions.js
@@ -21,14 +21,14 @@ export const LIKE_COMMENT_SUCCESS = '@comments/LIKE_COMMENT_SUCCESS';
 export const LIKE_COMMENT_ERROR = '@comments/LIKE_COMMENT_ERROR';
 
 export const RELOAD_EXISTING_COMMENT = '@comments/RELOAD_EXISTING_COMMENT';
-export const reloadExistingComment = createAction(RELOAD_EXISTING_COMMENT,
-  undefined,
-  data => ({ commentId: data.id }),
-);
+export const reloadExistingComment = createAction(RELOAD_EXISTING_COMMENT, undefined, data => ({
+  commentId: data.id,
+}));
 
-const getRootCommentsList = apiRes => Object.keys(apiRes.content)
-  .filter(commentKey => apiRes.content[commentKey].depth === 1)
-  .map(commentKey => apiRes.content[commentKey].id);
+const getRootCommentsList = apiRes =>
+  Object.keys(apiRes.content)
+    .filter(commentKey => apiRes.content[commentKey].depth === 1)
+    .map(commentKey => apiRes.content[commentKey].id);
 
 const getCommentsChildrenLists = (apiRes) => {
   const listsById = {};
@@ -48,117 +48,118 @@ const getCommentsChildrenLists = (apiRes) => {
  * preventing loading icon to be dispalyed
  * @param {object} focusedComment Object with author and permlink to which focus after loading
  */
-export const getComments = (postId, reload = false, focusedComment = undefined) =>
-  (dispatch, getState, { steemAPI }) => {
-    const { posts } = getState();
+export const getComments = (postId, reload = false, focusedComment = undefined) => (
+  dispatch,
+  getState,
+  { steemAPI },
+) => {
+  const { posts, comments } = getState();
 
-    const content = posts.list[postId];
+  const content = posts.list[postId] || comments.comments[postId];
 
-    const { category, author, permlink } = content;
+  const { category, author, permlink } = content;
 
-    dispatch({
-      type: GET_COMMENTS,
-      payload: {
-        promise: steemAPI.getStateAsync(`/${category}/@${author}/${permlink}`).then(apiRes => ({
-          rootCommentsList: getRootCommentsList(apiRes),
-          commentsChildrenList: getCommentsChildrenLists(apiRes),
-          content: apiRes.content,
-        })),
-      },
-      meta: {
-        id: postId,
-        reload,
-        focusedComment,
-      },
-    });
-  };
+  dispatch({
+    type: GET_COMMENTS,
+    payload: {
+      promise: steemAPI.getStateAsync(`/${category}/@${author}/${permlink}`).then(apiRes => ({
+        rootCommentsList: getRootCommentsList(apiRes),
+        commentsChildrenList: getCommentsChildrenLists(apiRes),
+        content: apiRes.content,
+      })),
+    },
+    meta: {
+      id: postId,
+      reload,
+      focusedComment,
+    },
+  });
+};
 
-export const sendComment = (parentPost, body, isUpdating = false, originalComment) =>
-  (dispatch, getState) => {
-    const {
-      category,
-      root_comment: rootComment,
-      permlink: parentPermlink,
-      author: parentAuthor,
-    } = parentPost;
-    const { auth } = getState();
+export const sendComment = (parentPost, body, isUpdating = false, originalComment) => (
+  dispatch,
+  getState,
+) => {
+  const { category, id, permlink: parentPermlink, author: parentAuthor } = parentPost;
+  const { auth } = getState();
 
-    if (!auth.isAuthenticated) {
-      return dispatch(notify('You have to be logged in to comment', 'error'));
+  if (!auth.isAuthenticated) {
+    return dispatch(notify('You have to be logged in to comment', 'error'));
+  }
+
+  if (!body || !body.length) {
+    return dispatch(notify("Message can't be empty", 'error'));
+  }
+
+  const author = auth.user.name;
+  const permlink = isUpdating
+    ? originalComment.permlink
+    : createCommentPermlink(parentAuthor, parentPermlink);
+  const jsonMetadata = { tags: [category], community: 'busy', app: `busy/${version}` };
+
+  const newBody = isUpdating ? getBodyPatchIfSmaller(originalComment.body, body) : body;
+
+  return dispatch({
+    type: SEND_COMMENT,
+    payload: {
+      promise: SteemConnect.comment(
+        parentAuthor,
+        parentPermlink,
+        author,
+        permlink,
+        '',
+        newBody,
+        jsonMetadata,
+      ).then((resp) => {
+        const focusedComment = {
+          author: resp.result.operations[0][1].author,
+          permlink: resp.result.operations[0][1].permlink,
+        };
+        dispatch(notify('Comment submitted successfully', 'success'));
+        dispatch(getComments(id, true, focusedComment));
+        if (window.ga) {
+          window.ga('send', 'event', 'comment', 'submit', '', 5);
+        }
+      }),
+    },
+    meta: {
+      parentId: parentPost.id,
+      isEditing: false,
+      isReplyToComment: parentPost.id !== id,
+    },
+  });
+};
+
+export const likeComment = (commentId, weight = 10000, vote = 'like', retryCount = 0) => (
+  dispatch,
+  getState,
+  { steemAPI },
+) => {
+  const { auth, comments } = getState();
+
+  if (!auth.isAuthenticated) {
+    return;
+  }
+
+  const voter = auth.user.name;
+  const { author, permlink } = comments.comments[commentId];
+
+  dispatch({
+    type: LIKE_COMMENT,
+    payload: {
+      promise: SteemConnect.vote(voter, author, permlink, weight).then((res) => {
+        // reload comment data to fetch payout after vote
+        steemAPI.getContentAsync(author, permlink).then((data) => {
+          dispatch(reloadExistingComment(data));
+          return data;
+        });
+        return res;
+      }),
+    },
+    meta: { commentId, voter, weight, vote, isRetry: retryCount > 0 },
+  }).catch((err) => {
+    if (err.res && err.res.status === 500 && retryCount <= 5) {
+      dispatch(likeComment(commentId, weight, vote, retryCount + 1));
     }
-
-    if (!body || !body.length) {
-      return dispatch(notify("Message can't be empty", 'error'));
-    }
-
-    const author = auth.user.name;
-    const permlink = isUpdating
-      ? originalComment.permlink
-      : createCommentPermlink(parentAuthor, parentPermlink);
-    const jsonMetadata = { tags: [category], community: 'busy', app: `busy/${version}` };
-
-    const newBody = isUpdating ? getBodyPatchIfSmaller(originalComment.body, body) : body;
-
-    return dispatch({
-      type: SEND_COMMENT,
-      payload: {
-        promise: SteemConnect.comment(
-          parentAuthor,
-          parentPermlink,
-          author,
-          permlink,
-          '',
-          newBody,
-          jsonMetadata,
-        )
-          .then((resp) => {
-            const focusedComment = {
-              author: resp.result.operations[0][1].author,
-              permlink: resp.result.operations[0][1].permlink,
-            };
-            dispatch(notify('Comment submitted successfully', 'success'));
-            dispatch(getComments(rootComment, true, focusedComment));
-
-            if (window.ga) {
-              window.ga('send', 'event', 'comment', 'submit', '', 5);
-            }
-          }),
-      },
-      meta: {
-        parentId: parentPost.id,
-        isEditing: false,
-        isReplyToComment: parentPost.id !== rootComment,
-      },
-    });
-  };
-
-export const likeComment = (commentId, weight = 10000, vote = 'like', retryCount = 0) =>
-  (dispatch, getState, { steemAPI }) => {
-    const { auth, comments } = getState();
-
-    if (!auth.isAuthenticated) {
-      return;
-    }
-
-    const voter = auth.user.name;
-    const { author, permlink } = comments.comments[commentId];
-
-    dispatch({
-      type: LIKE_COMMENT,
-      payload: {
-        promise: SteemConnect.vote(voter, author, permlink, weight).then((res) => {
-          // reload comment data to fetch payout after vote
-          steemAPI.getContentAsync(author, permlink).then((data) => {
-            dispatch(reloadExistingComment(data));
-            return data;
-          });
-          return res;
-        }),
-      },
-      meta: { commentId, voter, weight, vote, isRetry: retryCount > 0 },
-    }).catch((err) => {
-      if (err.res && err.res.status === 500 && retryCount <= 5) {
-        dispatch(likeComment(commentId, weight, vote, retryCount + 1));
-      }
-    });
-  };
+  });
+};


### PR DESCRIPTION
This fixes issue with comments not reloading after commenting on comment displayed as single post + makes reloading comments more efficient by reloading parent not root comments.
https://trello.com/c/sqhK9jpK/292-bug-commenting-with-comment-link