### PR TITLE
Replace margin with padding for .ant-form-item

### DIFF
--- a/src/components/Editor/Editor.less
+++ b/src/components/Editor/Editor.less
@@ -3,6 +3,11 @@
 .Editor {
   padding-bottom: 24px;
 
+  .ant-form-item {
+    margin-bottom: 0px;
+    padding-bottom: 24px;
+  }
+
   &__hidden {
     display: none !important;
   }


### PR DESCRIPTION
Fixes issue with error message overlapping editor
![image](https://user-images.githubusercontent.com/1968722/31565030-93c0b394-b065-11e7-8ccd-18a3efe1e67c.png)
https://trello.com/c/xhdS5lhK/309-edit-post-tag-text-overflow