### PR TITLE
german grammar fix

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -166,7 +166,7 @@
   "payout_author_payout_amount":"Autor Auszahlung: {amount}",
   "payout_curators_payout_amount":"Kuratoren-Auszahlung: {amount}",
   "payout_potential_payout_amount":"Mögliche Auszahlung: {amount}",
-  "payout_will_release_in_time":"Wird ausgezahlt in {time}",
+  "payout_will_release_in_time":"Wird {time} ausgezahlt",
   "payout_declined":"Auszahlung abgelehnt",
   "rank_plankton":"Plankton",
   "rank_minnow":"Kleiner Fisch",


### PR DESCRIPTION
German grammar fix from https://github.com/busyorg/busy/pull/870 and https://github.com/busyorg/busy/pull/855. Was overridden in https://github.com/busyorg/busy/pull/873 (https://github.com/busyorg/busy/pull/873/commits/e67ce5fb53da1cc204b71c1157881f2bc16b0adf).

