### PR TITLE
Fix for #869: Be able to click on voted Users

### DIFF
--- a/src/components/Story/StoryFooter.js
+++ b/src/components/Story/StoryFooter.js
@@ -116,7 +116,10 @@ class StoryFooter extends React.Component {
 
     const upVotesPreview = take(upVotes, 10).map(vote => (
       <p key={vote.voter}>
-        {vote.voter}
+        <Link to={`/@${vote.voter}`}>
+          {vote.voter}
+        </Link>
+
         {vote.rshares * ratio > 0.01 && (
           <span style={{ opacity: '0.5' }}>
             {' '}

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -29,9 +29,6 @@ body {
   a {
     color: @white;
   }
-  a:hover {
-    color: @primary-5;
-  }
 }
 
 .ant-popover-title {

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -26,6 +26,12 @@ body {
 
 .ant-tooltip-content {
   font-weight: 500;
+  a {
+    color: @white;
+  }
+  a:hover {
+    color: @primary-5;
+  }
 }
 
 .ant-popover-title {


### PR DESCRIPTION
I saw this was tagged as a good first issue so I decided to take it on.

The original issue, making the users clickable in the tooltip, is of course very straightforward.

However I had to dig into some of the specifics of the LESS precedence order to get the desired behavior in the file that seems to be the place designated for a LESS override on AntDesign's rules.

Here's what I ran into:

- Adding a `<Link>` to the tooltip expectedly renders to an `<a>` tag
- AntDesign's antd.less defines the `@link-color` to be our @primary-color, which is `@purple`
- We override antd.less's `@tooltip-bg` to also be `@purple`
- Therefore, when the link renders, the text becomes invisible since both the `@link-color` and `@tooltip-bg` are `@purple`. Furthermore, we obviously want `@link-color` to remain `@purple` everywhere but on the tooltip.

So, naturally, I found in common.less, that we've already defined some overrides for antd.less's tooltip:
```
.ant-tooltip-content {
  font-weight: 500;
}
```

which makes it a great location to put in the additional rule of making the link color `@white` inside of the tooltip:

```
.ant-tooltip-content {
  font-weight: 500;
  a {
    color: @white;
  }
}
```

However, since we load antd.less first in custom.less, and then load common.less, we run into an interesting precedence condition, mainly that:
- `.ant-tooltip-content > a { color: white }` ends up overriding the `a:hover` selector from antd.less
- The outcome is then undesirable, because the link remains `@white`, even on hover

The fix I went with was to simply define the hover behavior in common.less as it is in antd.less. They define `a:hover` behavior to effectively be:
```
a:hover {
    color: @primary-5;
}
```

where [`@primary-5`](https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less#L22) is our `@primary color` (`@purple`), with a 20% tint.

So the fix for the link color becomes:
```
.ant-tooltip-content {
  font-weight: 500;
  a {
    color: @white;
  }
  a:hover {
      color: @primary-5;
  }
}
```

resulting in what I think is desirable behavior that:
- We can define our override to the tooltip link color in common.less
- The link inside of the tooltip is `@white`, and not hidden by being the same color as `@tooltip-bg`
- The `a:hover` behavior inside the tooltip is not overridden by this rule


Let me know what you think of my approach to the fix and if you'd like to see any changes.