### PR TITLE
Remove uncovered branches related to file upload

### DIFF
--- a/src/post/Write/editorReducer.js
+++ b/src/post/Write/editorReducer.js
@@ -1,7 +1,6 @@
 import * as authActions from '../../auth/authActions';
 import * as editorActions from './editorActions';
 import * as postActions from '../postActions';
-import * as userActions from '../../user/userActions';
 
 const defaultState = {
   loading: false,
@@ -18,10 +17,7 @@ const editor = (state = defaultState, action) => {
     case editorActions.ADD_EDITED_POST:
       return {
         ...state,
-        editedPosts: [
-          ...state.editedPosts,
-          action.payload,
-        ],
+        editedPosts: [...state.editedPosts, action.payload],
       };
     case postActions.GET_CONTENT_SUCCESS:
       return {
@@ -86,10 +82,7 @@ const editor = (state = defaultState, action) => {
     case editorActions.DELETE_DRAFT_START:
       return {
         ...state,
-        pendingDrafts: [
-          ...state.pendingDrafts,
-          action.meta.id,
-        ],
+        pendingDrafts: [...state.pendingDrafts, action.meta.id],
       };
     case editorActions.DELETE_DRAFT_SUCCESS: {
       return {
@@ -103,12 +96,6 @@ const editor = (state = defaultState, action) => {
         ...state,
         pendingDrafts: state.pendingDrafts.filter(id => id !== action.meta.id),
       };
-    case userActions.UPLOAD_FILE_START:
-      return { ...state, loadingImg: true };
-
-    case userActions.UPLOAD_FILE_ERROR:
-    case userActions.UPLOAD_FILE_SUCCESS:
-      return { ...state, loadingImg: false };
     default:
       return state;
   }

--- a/src/user/userReducer.js
+++ b/src/user/userReducer.js
@@ -1,17 +1,6 @@
-import keyBy from 'lodash/keyBy';
-import omit from 'lodash/omit';
-
 import * as actions from './userActions';
 
 const initialState = {
-  // Map<FilePublicId, File>
-  files: {},
-  // Whether a file is uploading.
-  // Map<FileName, Bool>
-  fileUploadIsLoading: {},
-  fileUploadError: null,
-  filesFetchError: null,
-  filesFetchIsLoading: true,
   following: {
     list: [],
     pendingFollows: [],
@@ -21,56 +10,6 @@ const initialState = {
 
 export default function userReducer(state = initialState, action) {
   switch (action.type) {
-    case actions.UPLOAD_FILE_START: {
-      return {
-        ...state,
-        fileUploadIsLoading: {
-          ...state.fileUploadIsLoading,
-          [action.meta.filename]: true,
-        },
-        fileUploadError: null,
-      };
-    }
-    case actions.UPLOAD_FILE_SUCCESS: {
-      return {
-        ...state,
-        files: {
-          ...state.files,
-          [action.payload.public_id]: action.payload,
-        },
-        fileUploadIsLoading: omit(state.fileUploadIsLoading, [action.meta.filename]),
-        fileUploadError: null,
-      };
-    }
-    case actions.UPLOAD_FILE_ERROR: {
-      return {
-        ...state,
-        fileUploadIsLoading: omit(state.fileUploadIsLoading, [action.meta.filename]),
-        fileUploadError: action.payload,
-      };
-    }
-    case actions.FETCH_FILES_START: {
-      return {
-        ...state,
-        filesFetchIsLoading: true,
-        filesFetchError: null,
-      };
-    }
-    case actions.FETCH_FILES_SUCCESS: {
-      return {
-        ...state,
-        files: keyBy(action.payload, 'public_id'),
-        filesFetchIsLoading: false,
-        filesFetchError: null,
-      };
-    }
-    case actions.FETCH_FILES_ERROR: {
-      return {
-        ...state,
-        filesFetchIsLoading: false,
-        filesFetchError: action.payload,
-      };
-    }
     case actions.GET_FOLLOWING_START:
       return {
         ...state,


### PR DESCRIPTION
This PR removes uncovered cases (related to old file upload functionality) in user and editor reducers, and removes any state properties that they referenced, so there are no warnings about not existing imports.

This error:
```
/node_modules/css-loader!./node_modules/postcss-loader/lib?{"ident":"postcss","plugins":[null,null]}!./node_modules/less-loader/dist/cjs.js!./src/styles/base.less
(Emitted value instead of an instance of Error) autoprefixer: /home/sekhmet/Workspace/busy/src/styles/base.less:13206:3: Second Autoprefixer control comment was ignored. Autoprefixer applies control comment to whole block, not to next rules.
```
is caused by bug in antd and was already fixed in 3.0 alpha (so it will go away after upgrading).