### PR TITLE
Add Avatar image error handler

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -22,7 +22,7 @@ class Avatar extends Component {
 
   onError = () => {
     this.setState({
-      imgUrl: 'https://res.cloudinary.com/hpiynhbhq/image/fetch/s--hWKFE2sA--/c_fill,h_200,w_200/http://res.cloudinary.com/hpiynhbhq/image/upload/v1501526513/avatar_juzb7o.png',
+      imgUrl: 'https://res.cloudinary.com/hpiynhbhq/image/upload/v1506948447/p72avlprkfariyti7q2l.png',
     });
   };
 

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,23 +1,45 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './Avatar.less';
 
-const Avatar = ({ username, size }) =>
-  (<img
-    className="Avatar"
-    style={{ minWidth: `${size}px`, width: `${size}px`, height: `${size}px` }}
-    alt={username}
-    src={`${process.env.IMG_HOST}/@${username || 'steemconnect'}?s=${size}`}
-  />);
+class Avatar extends Component {
+  static propTypes = {
+    username: PropTypes.string,
+    size: PropTypes.number,
+  };
 
-Avatar.propTypes = {
-  username: PropTypes.string,
-  size: PropTypes.number,
-};
+  static defaultProps = {
+    username: undefined,
+    size: 34,
+  };
 
-Avatar.defaultProps = {
-  username: undefined,
-  size: 34,
-};
+  constructor(props) {
+    super(props);
+    this.state = {
+      imgUrl: `${process.env.IMG_HOST}/@${props.username || 'steemconnect'}?s=${props.size}`,
+    };
+  }
+
+  onError = () => {
+    this.setState({
+      imgUrl: 'defaultImgUrl',
+    });
+  };
+
+  render() {
+    const { username, size } = this.props;
+    const { imgUrl } = this.state;
+
+    return (
+      <img
+        className="Avatar"
+        style={{ minWidth: `${size}px`, width: `${size}px`, height: `${size}px` }}
+        onError={this.onError}
+        alt={username}
+        src={imgUrl}
+      />
+    );
+  }
+}
 
 export default Avatar;

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -22,7 +22,7 @@ class Avatar extends Component {
 
   onError = () => {
     this.setState({
-      imgUrl: 'defaultImgUrl',
+      imgUrl: 'https://res.cloudinary.com/hpiynhbhq/image/fetch/s--hWKFE2sA--/c_fill,h_200,w_200/http://res.cloudinary.com/hpiynhbhq/image/upload/v1501526513/avatar_juzb7o.png',
     });
   };
 

--- a/src/stories/__snapshots__/stories.test.js.snap
+++ b/src/stories/__snapshots__/stories.test.js.snap
@@ -796,6 +796,7 @@ exports[`Storyshots Navigation Topnav logged 1`] = `
                 <img
                   alt="guest123"
                   className="Avatar"
+                  onError={[Function]}
                   src="https://img.busy.org/@guest123?s=36"
                   style={
                     Object {
@@ -1020,6 +1021,7 @@ exports[`Storyshots Profile UserHeader 1`] = `
       <img
         alt=""
         className="Avatar"
+        onError={[Function]}
         src="https://img.busy.org/@steemconnect?s=100"
         style={
           Object {
@@ -1205,6 +1207,7 @@ exports[`Storyshots Sidebar Interesting People 1`] = `
               <img
                 alt="liondani"
                 className="Avatar"
+                onError={[Function]}
                 src="https://img.busy.org/@liondani?s=34"
                 style={
                   Object {
@@ -1252,6 +1255,7 @@ exports[`Storyshots Sidebar Interesting People 1`] = `
               <img
                 alt="good-karma"
                 className="Avatar"
+                onError={[Function]}
                 src="https://img.busy.org/@good-karma?s=34"
                 style={
                   Object {
@@ -1299,6 +1303,7 @@ exports[`Storyshots Sidebar Interesting People 1`] = `
               <img
                 alt="furion"
                 className="Avatar"
+                onError={[Function]}
                 src="https://img.busy.org/@furion?s=34"
                 style={
                   Object {
@@ -1672,6 +1677,7 @@ exports[`Storyshots Story Full story 1`] = `
         <img
           alt="bitspace"
           className="Avatar"
+          onError={[Function]}
           src="https://img.busy.org/@bitspace?s=60"
           style={
             Object {
@@ -1938,6 +1944,7 @@ exports[`Storyshots Story Full story with embed 1`] = `
         <img
           alt="fyrstikken"
           className="Avatar"
+          onError={[Function]}
           src="https://img.busy.org/@fyrstikken?s=60"
           style={
             Object {
@@ -2188,6 +2195,7 @@ exports[`Storyshots Story Inline story 1`] = `
           <img
             alt="bitspace"
             className="Avatar"
+            onError={[Function]}
             src="https://img.busy.org/@bitspace?s=40"
             style={
               Object {
@@ -2412,6 +2420,7 @@ exports[`Storyshots Story Inline story with embed 1`] = `
           <img
             alt="fyrstikken"
             className="Avatar"
+            onError={[Function]}
             src="https://img.busy.org/@fyrstikken?s=40"
             style={
               Object {


### PR DESCRIPTION
* When img.busy randomly goes down, we need to replace avatar with a default avatar
* Add onError handler to img tag

@Sekhmet @bonustrack - this is a possible solution to when `img.busy` randomly goes down. What default avatar url should I use?