### PR TITLE
Hide Interesting People for single post pages

### DIFF
--- a/src/app/Sidebar/RightSidebar.js
+++ b/src/app/Sidebar/RightSidebar.js
@@ -78,7 +78,7 @@ export default class RightSidebar extends React.Component {
             render={() => (
               <div>
                 {authenticatedUser.last_root_post === '1970-01-01T00:00:00' && <StartNow />}
-                {authenticated && this.props.recommendations.length > 0
+                {authenticated && this.props.recommendations.length > 0 && !showPostRecommendation
                   ? <InterestingPeople
                     users={this.props.recommendations}
                     onRefresh={this.handleInterestingPeopleRefresh}


### PR DESCRIPTION
Fixes # https://github.com/busyorg/busy/issues/915

Changes:
- check for showPostRecommendation flag in RightSidebar