### PR TITLE
Change Buttons__link color and transition

### DIFF
--- a/src/components/StoryFooter/Buttons.less
+++ b/src/components/StoryFooter/Buttons.less
@@ -13,6 +13,9 @@
   }
 
   &__link {
+    color: @blue-botticelli;
+    transition: none;
+
     & > .iconfont {
       margin-right: 4px;
       font-size: 24px !important;


### PR DESCRIPTION
Fixes #933

Changes:
- Use `#99aab5` for default link color
- Remove transition so colour change matches icon transition

![933](https://user-images.githubusercontent.com/1968722/32143195-27443d2e-bca6-11e7-9417-f68f6fec9e50.gif)

