### PR TITLE
Add SteemTrendingCharts to User Wallet Pages & display delegated SP

### DIFF
--- a/src/app/Sidebar/RightSidebar.js
+++ b/src/app/Sidebar/RightSidebar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import {
   getIsAuthenticated,
   getAuthenticatedUser,
@@ -16,7 +16,9 @@ import StartNow from '../../components/Sidebar/StartNow';
 import SignUp from '../../components/Sidebar/SignUp';
 import PostRecommendation from '../../components/Sidebar/PostRecommendation';
 import Loading from '../../components/Icon/Loading';
+import SteemTrendingCharts from '../../components/Sidebar/SteemTrendingCharts';
 
+@withRouter
 @connect(
   state => ({
     authenticated: getIsAuthenticated(state),
@@ -64,6 +66,7 @@ export default class RightSidebar extends React.Component {
       <div>
         {!authenticated && <SignUp />}
         <Switch>
+          <Route path="/@:name/transfers" render={() => <SteemTrendingCharts />} />
           <Route
             path="/@:name"
             render={() =>

--- a/src/vendor/steemitHelpers.js
+++ b/src/vendor/steemitHelpers.js
@@ -172,3 +172,21 @@ export const calculateVoteValue = (vests, recentClaims, rewardBalance, vp = 1000
   const rshares = (power * vestingShares) / 10000;
   return rshares / recentClaims * rewardBalance;
 };
+
+export const calculateTotalDelegatedSP = (user, totalVestingShares, totalVestingFundSteem) => {
+  const receivedSP = parseFloat(
+    steem.formatter.vestToSteem(
+      user.received_vesting_shares,
+      totalVestingShares,
+      totalVestingFundSteem,
+    ),
+  );
+  const delegatedSP = parseFloat(
+    steem.formatter.vestToSteem(
+      user.delegated_vesting_shares,
+      totalVestingShares,
+      totalVestingFundSteem,
+    ),
+  );
+  return receivedSP - delegatedSP;
+};

--- a/src/wallet/ClaimReward.js
+++ b/src/wallet/ClaimReward.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import steem from 'steem';
-import { FormattedMessage, FormattedRelative, FormattedNumber } from 'react-intl';
+import {
+  FormattedMessage,
+  FormattedRelative,
+  FormattedNumber,
+  FormattedDate,
+  FormattedTime,
+} from 'react-intl';
+import { Tooltip } from 'antd';
 
 const getFormattedPayout = (
   rewardSteem,
@@ -85,7 +92,16 @@ const ClaimReward = ({
         </span>
       </div>
       <span className="UserWalletTransactions__timestamp">
-        <FormattedRelative value={`${timestamp}Z`} />
+        <Tooltip
+          title={
+            <span>
+              <FormattedDate value={`${timestamp}Z`} />{' '}
+              <FormattedTime value={`${timestamp}Z`} />
+            </span>
+          }
+        >
+          <span><FormattedRelative value={`${timestamp}Z`} /></span>
+        </Tooltip>
       </span>
     </div>
   </div>

--- a/src/wallet/PowerUpTransaction.js
+++ b/src/wallet/PowerUpTransaction.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
+import { FormattedMessage, FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
+import { Tooltip } from 'antd';
 
 const PowerUpTransaction = ({ timestamp, amount }) => (
   <div className="UserWalletTransactions__transaction">
@@ -15,7 +16,18 @@ const PowerUpTransaction = ({ timestamp, amount }) => (
         </span>
       </div>
       <span className="UserWalletTransactions__timestamp">
-        <FormattedRelative value={`${timestamp}Z`} />
+        <Tooltip
+          title={
+            <span>
+              <FormattedDate value={`${timestamp}Z`} />{' '}
+              <FormattedTime value={`${timestamp}Z`} />
+            </span>
+          }
+        >
+          <span>
+            <FormattedRelative value={`${timestamp}Z`} />
+          </span>
+        </Tooltip>
       </span>
     </div>
   </div>

--- a/src/wallet/ReceiveTransaction.js
+++ b/src/wallet/ReceiveTransaction.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
+import { FormattedMessage, FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
+import { Tooltip } from 'antd';
 import Avatar from '../components/Avatar';
-
 
 const ReceiveTransaction = ({ from, memo, amount, timestamp }) => (
   <div className="UserWalletTransactions__transaction">
@@ -24,7 +24,16 @@ const ReceiveTransaction = ({ from, memo, amount, timestamp }) => (
         </span>
       </div>
       <span className="UserWalletTransactions__timestamp">
-        <FormattedRelative value={`${timestamp}Z`} />
+        <Tooltip
+          title={
+            <span>
+              <FormattedDate value={`${timestamp}Z`} />{' '}
+              <FormattedTime value={`${timestamp}Z`} />
+            </span>
+          }
+        >
+          <span><FormattedRelative value={`${timestamp}Z`} /></span>
+        </Tooltip>
       </span>
       <span className="UserWalletTransactions__memo">
         {memo}

--- a/src/wallet/SavingsTransaction.js
+++ b/src/wallet/SavingsTransaction.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
+import { FormattedMessage, FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
+import { Tooltip } from 'antd';
 import Avatar from '../components/Avatar';
 
 const getSavingsTransactionMessage = (transactionType, transactionDetails, amount) => {
@@ -60,7 +61,16 @@ const SavingsTransaction = ({ timestamp, transactionType, transactionDetails, am
         {getSavingsTransactionMessage(transactionType, transactionDetails, amount)}
       </div>
       <span className="UserWalletTransactions__timestamp">
-        <FormattedRelative value={`${timestamp}Z`} />
+        <Tooltip
+          title={
+            <span>
+              <FormattedDate value={`${timestamp}Z`} />{' '}
+              <FormattedTime value={`${timestamp}Z`} />
+            </span>
+          }
+        >
+          <span><FormattedRelative value={`${timestamp}Z`} /></span>
+        </Tooltip>
       </span>
       <span className="UserWalletTransactions__memo">
         {transactionDetails.memo}

--- a/src/wallet/TransferTransaction.js
+++ b/src/wallet/TransferTransaction.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedRelative } from 'react-intl';
 import { Link } from 'react-router-dom';
+import { FormattedMessage, FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
+import { Tooltip } from 'antd';
 import Avatar from '../components/Avatar';
 
 const TransferTransaction = ({ to, memo, amount, timestamp }) => (
@@ -23,7 +24,16 @@ const TransferTransaction = ({ to, memo, amount, timestamp }) => (
         </span>
       </div>
       <span className="UserWalletTransactions__timestamp">
-        <FormattedRelative value={`${timestamp}Z`} />
+        <Tooltip
+          title={
+            <span>
+              <FormattedDate value={`${timestamp}Z`} />{' '}
+              <FormattedTime value={`${timestamp}Z`} />
+            </span>
+          }
+        >
+          <span><FormattedRelative value={`${timestamp}Z`} /></span>
+        </Tooltip>
       </span>
       <span className="UserWalletTransactions__memo">
         {memo}

--- a/src/wallet/UserWalletSummary.js
+++ b/src/wallet/UserWalletSummary.js
@@ -14,14 +14,14 @@ const getFormattedTotalDelegatedSP = (user, totalVestingShares, totalVestingFund
     totalVestingFundSteem,
   );
 
-  if (totalDelegatedSP > 0) {
+  if (totalDelegatedSP !== 0) {
     return (
       <span>
-        {'(+'}
+        {totalDelegatedSP > 0 ? '(+' : '('}
         <FormattedNumber
           value={calculateTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
         />
-        {'SP)'}
+        {' SP)'}
       </span>
     );
   }

--- a/src/wallet/UserWalletSummary.js
+++ b/src/wallet/UserWalletSummary.js
@@ -2,9 +2,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import steem from 'steem';
+import { calculateTotalDelegatedSP } from '../vendor/steemitHelpers';
 import Loading from '../components/Icon/Loading';
 import USDDisplay from '../components/Utils/USDDisplay';
 import './UserWalletSummary.less';
+
+const getFormattedTotalDelegatedSP = (user, totalVestingShares, totalVestingFundSteem) => {
+  const totalDelegatedSP = calculateTotalDelegatedSP(
+    user,
+    totalVestingShares,
+    totalVestingFundSteem,
+  );
+
+  if (totalDelegatedSP > 0) {
+    return (
+      <span>
+        {' (+'}
+        <FormattedNumber
+          value={calculateTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
+        />
+        {' SP'}
+        {')'}
+      </span>
+    );
+  }
+
+  return null;
+};
 
 const UserWalletSummary = ({
   user,
@@ -27,17 +51,6 @@ const UserWalletSummary = ({
       </div>
     </div>
     <div className="UserWalletSummary__item">
-      <i className="iconfont icon-Dollar UserWalletSummary__icon" />
-      <div className="UserWalletSummary__label">
-        <FormattedMessage id="steem_dollar" defaultMessage="Steem Dollar" />
-      </div>
-      <div className="UserWalletSummary__value">
-        {loading
-          ? <Loading />
-          : <span><FormattedNumber value={parseFloat(user.sbd_balance)} />{' SBD'}</span>}
-      </div>
-    </div>
-    <div className="UserWalletSummary__item">
       <i className="iconfont icon-flashlight_fill UserWalletSummary__icon" />
       <div className="UserWalletSummary__label">
         <FormattedMessage id="steem_power" defaultMessage="Steem Power" />
@@ -56,7 +69,19 @@ const UserWalletSummary = ({
               )}
             />
             {' SP'}
+            {getFormattedTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
           </span>}
+      </div>
+    </div>
+    <div className="UserWalletSummary__item">
+      <i className="iconfont icon-Dollar UserWalletSummary__icon" />
+      <div className="UserWalletSummary__label">
+        <FormattedMessage id="steem_dollar" defaultMessage="Steem Dollar" />
+      </div>
+      <div className="UserWalletSummary__value">
+        {loading
+          ? <Loading />
+          : <span><FormattedNumber value={parseFloat(user.sbd_balance)} />{' SBD'}</span>}
       </div>
     </div>
     <div className="UserWalletSummary__item">

--- a/src/wallet/UserWalletSummary.js
+++ b/src/wallet/UserWalletSummary.js
@@ -17,12 +17,11 @@ const getFormattedTotalDelegatedSP = (user, totalVestingShares, totalVestingFund
   if (totalDelegatedSP > 0) {
     return (
       <span>
-        {' (+'}
+        {'(+'}
         <FormattedNumber
           value={calculateTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
         />
-        {' SP'}
-        {')'}
+        {'SP)'}
       </span>
     );
   }
@@ -68,7 +67,7 @@ const UserWalletSummary = ({
                 ),
               )}
             />
-            {' SP'}
+            {' SP '}
             {getFormattedTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
           </span>}
       </div>

--- a/src/wallet/Wallet.js
+++ b/src/wallet/Wallet.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { openTransfer } from '../wallet/walletActions';
 import Affix from '../components/Utils/Affix';
 import LeftSidebar from '../app/Sidebar/LeftSidebar';
+import Action from '../components/Button/Action';
 import SteemTrendingCharts from '../components/Sidebar/SteemTrendingCharts';
 import UserWallet from '../user/UserWallet';
 
-const Wallet = () => (
+const Wallet = props => (
   <div className="shifted">
     <div className="feed-layout container">
       <Affix className="leftContainer" stickPosition={77}>
@@ -15,6 +20,14 @@ const Wallet = () => (
       <Affix className="rightContainer" stickPosition={77}>
         <div className="right">
           <SteemTrendingCharts />
+          <Action
+            style={{ margin: '10px 0' }}
+            text={props.intl.formatMessage({
+              id: 'transfer',
+              defaultMessage: 'Transfer',
+            })}
+            onClick={() => props.openTransfer('')}
+          />
         </div>
       </Affix>
       <div className="center">
@@ -23,4 +36,12 @@ const Wallet = () => (
     </div>
   </div>
 );
-export default Wallet;
+
+Wallet.propTypes = {
+  openTransfer: PropTypes.func.isRequired,
+  intl: PropTypes.shape().isRequired,
+};
+
+export default connect(null, {
+  openTransfer,
+})(injectIntl(Wallet));

--- a/src/wallet/__tests__/ClaimReward.test.js
+++ b/src/wallet/__tests__/ClaimReward.test.js
@@ -10,6 +10,8 @@ describe('(Component) ClaimReward', () => {
         rewardSteem: '0 STEEM',
         rewardSbd: '0 SBD',
         rewardVests: '0 SP',
+        totalVestingShares: '0',
+        totalVestingFundSteem: '0',
       };
       const wrapper = shallow(<ClaimReward {...props} />);
       expect(wrapper).toMatchSnapshot();

--- a/src/wallet/__tests__/PowerUpTransaction.test.js
+++ b/src/wallet/__tests__/PowerUpTransaction.test.js
@@ -7,7 +7,7 @@ describe('(Component) PowerUpTransaction', () => {
     it('renders and matches snapshot', () => {
       const props = {
         timestamp: '0',
-        amount: '0 STEEM',
+        amount: <span>{'0 STEEM'}</span>,
       };
       const wrapper = shallow(<PowerUpTransaction {...props} />);
       expect(wrapper).toMatchSnapshot();

--- a/src/wallet/__tests__/ReceiveTransaction.test.js
+++ b/src/wallet/__tests__/ReceiveTransaction.test.js
@@ -8,7 +8,7 @@ describe('(Component) ReceiveTransaction', () => {
       const props = {
         from: 'hellosteem',
         memo: 'Test Memo',
-        amount: '100 STEEM',
+        amount: <span>{'0 STEEM'}</span>,
         timestamp: '0',
       };
       const wrapper = shallow(<ReceiveTransaction {...props} />);

--- a/src/wallet/__tests__/TransferTransaction.test.js
+++ b/src/wallet/__tests__/TransferTransaction.test.js
@@ -8,7 +8,7 @@ describe('(Component) TransferTransaction', () => {
       const props = {
         to: 'hellosteem',
         memo: 'Test Transfer Transaction',
-        amount: '100 STEEM',
+        amount: <span>{'0 STEEM'}</span>,
         timestamp: '0',
       };
       const wrapper = shallow(<TransferTransaction {...props} />);

--- a/src/wallet/__tests__/UserWalletTransactions.test.js
+++ b/src/wallet/__tests__/UserWalletTransactions.test.js
@@ -29,6 +29,8 @@ describe('(Component) UserWalletTransactions', () => {
           },
         ],
         currentUsername: 'hellosteem',
+        totalVestingShares: '0',
+        totalVestingFundSteem: '0',
       };
       const wrapper = shallow(<UserWalletTransactions {...props} />);
       expect(wrapper).toMatchSnapshot();

--- a/src/wallet/__tests__/__snapshots__/ClaimReward.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/ClaimReward.test.js.snap
@@ -91,6 +91,8 @@ ShallowWrapper {
         rewardSteem="0 STEEM"
         rewardVests="0 SP"
         timestamp="0"
+        totalVestingFundSteem="0"
+        totalVestingShares="0"
       />,
       "_debugID": 1,
       "_hostContainerInfo": null,
@@ -103,6 +105,8 @@ ShallowWrapper {
           "rewardSteem": "0 STEEM",
           "rewardVests": "0 SP",
           "timestamp": "0",
+          "totalVestingFundSteem": "0",
+          "totalVestingShares": "0",
         },
         "refs": Object {},
         "state": null,
@@ -211,6 +215,8 @@ ShallowWrapper {
     rewardSteem="0 STEEM"
     rewardVests="0 SP"
     timestamp="0"
+    totalVestingFundSteem="0"
+    totalVestingShares="0"
   />,
 }
 `;

--- a/src/wallet/__tests__/__snapshots__/ClaimReward.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/ClaimReward.test.js.snap
@@ -36,10 +36,33 @@ ShallowWrapper {
       <span
         className="UserWalletTransactions__timestamp"
       >
-        <FormattedRelative
-          updateInterval={10000}
-          value="0Z"
-        />
+        <Tooltip
+          arrowPointAtCenter={false}
+          autoAdjustOverflow={true}
+          mouseEnterDelay={0.1}
+          mouseLeaveDelay={0.1}
+          placement="top"
+          prefixCls="ant-tooltip"
+          title={
+            <span>
+              <FormattedDate
+                value="0Z"
+              />
+               
+              <FormattedTime
+                value="0Z"
+              />
+            </span>
+          }
+          transitionName="zoom-big-fast"
+        >
+          <span>
+            <FormattedRelative
+              updateInterval={10000}
+              value="0Z"
+            />
+          </span>
+        </Tooltip>
       </span>
     </div>
   </div>,
@@ -72,10 +95,33 @@ ShallowWrapper {
         <span
           className="UserWalletTransactions__timestamp"
         >
-          <FormattedRelative
-            updateInterval={10000}
-            value="0Z"
-          />
+          <Tooltip
+            arrowPointAtCenter={false}
+            autoAdjustOverflow={true}
+            mouseEnterDelay={0.1}
+            mouseLeaveDelay={0.1}
+            placement="top"
+            prefixCls="ant-tooltip"
+            title={
+              <span>
+                <FormattedDate
+                  value="0Z"
+                />
+                 
+                <FormattedTime
+                  value="0Z"
+                />
+              </span>
+            }
+            transitionName="zoom-big-fast"
+          >
+            <span>
+              <FormattedRelative
+                updateInterval={10000}
+                value="0Z"
+              />
+            </span>
+          </Tooltip>
         </span>
       </div>
     </div>,
@@ -156,10 +202,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
           </div>
         </div>,
@@ -192,10 +261,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
           </div>
         </div>,

--- a/src/wallet/__tests__/__snapshots__/PowerUpTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/PowerUpTransaction.test.js.snap
@@ -32,7 +32,9 @@ ShallowWrapper {
         <span
           className="UserWalletTransactions__payout"
         >
-          0 STEEM
+          <span>
+            0 STEEM
+          </span>
         </span>
       </div>
       <span
@@ -70,7 +72,9 @@ ShallowWrapper {
           <span
             className="UserWalletTransactions__payout"
           >
-            0 STEEM
+            <span>
+              0 STEEM
+            </span>
           </span>
         </div>
         <span
@@ -91,7 +95,11 @@ ShallowWrapper {
       "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <PowerUpTransaction
-        amount="0 STEEM"
+        amount={
+          <span>
+            0 STEEM
+          </span>
+        }
         timestamp="0"
       />,
       "_debugID": 1,
@@ -101,7 +109,9 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
-          "amount": "0 STEEM",
+          "amount": <span>
+            0 STEEM
+          </span>,
           "timestamp": "0",
         },
         "refs": Object {},
@@ -148,7 +158,9 @@ ShallowWrapper {
               <span
                 className="UserWalletTransactions__payout"
               >
-                0 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -186,7 +198,9 @@ ShallowWrapper {
               <span
                 className="UserWalletTransactions__payout"
               >
-                0 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -211,7 +225,11 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <PowerUpTransaction
-    amount="0 STEEM"
+    amount={
+      <span>
+        0 STEEM
+      </span>
+    }
     timestamp="0"
   />,
 }

--- a/src/wallet/__tests__/__snapshots__/PowerUpTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/PowerUpTransaction.test.js.snap
@@ -40,10 +40,33 @@ ShallowWrapper {
       <span
         className="UserWalletTransactions__timestamp"
       >
-        <FormattedRelative
-          updateInterval={10000}
-          value="0Z"
-        />
+        <Tooltip
+          arrowPointAtCenter={false}
+          autoAdjustOverflow={true}
+          mouseEnterDelay={0.1}
+          mouseLeaveDelay={0.1}
+          placement="top"
+          prefixCls="ant-tooltip"
+          title={
+            <span>
+              <FormattedDate
+                value="0Z"
+              />
+               
+              <FormattedTime
+                value="0Z"
+              />
+            </span>
+          }
+          transitionName="zoom-big-fast"
+        >
+          <span>
+            <FormattedRelative
+              updateInterval={10000}
+              value="0Z"
+            />
+          </span>
+        </Tooltip>
       </span>
     </div>
   </div>,
@@ -80,10 +103,33 @@ ShallowWrapper {
         <span
           className="UserWalletTransactions__timestamp"
         >
-          <FormattedRelative
-            updateInterval={10000}
-            value="0Z"
-          />
+          <Tooltip
+            arrowPointAtCenter={false}
+            autoAdjustOverflow={true}
+            mouseEnterDelay={0.1}
+            mouseLeaveDelay={0.1}
+            placement="top"
+            prefixCls="ant-tooltip"
+            title={
+              <span>
+                <FormattedDate
+                  value="0Z"
+                />
+                 
+                <FormattedTime
+                  value="0Z"
+                />
+              </span>
+            }
+            transitionName="zoom-big-fast"
+          >
+            <span>
+              <FormattedRelative
+                updateInterval={10000}
+                value="0Z"
+              />
+            </span>
+          </Tooltip>
         </span>
       </div>
     </div>,
@@ -166,10 +212,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
           </div>
         </div>,
@@ -206,10 +275,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
           </div>
         </div>,

--- a/src/wallet/__tests__/__snapshots__/ReceiveTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/ReceiveTransaction.test.js.snap
@@ -43,7 +43,9 @@ ShallowWrapper {
           className="UserWalletTransactions__received"
         >
           + 
-          100 STEEM
+          <span>
+            0 STEEM
+          </span>
         </span>
       </div>
       <span
@@ -97,7 +99,9 @@ ShallowWrapper {
             className="UserWalletTransactions__received"
           >
             + 
-            100 STEEM
+            <span>
+              0 STEEM
+            </span>
           </span>
         </div>
         <span
@@ -123,7 +127,11 @@ ShallowWrapper {
       "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <ReceiveTransaction
-        amount="100 STEEM"
+        amount={
+          <span>
+            0 STEEM
+          </span>
+        }
         from="hellosteem"
         memo="Test Memo"
         timestamp="0"
@@ -135,7 +143,9 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
-          "amount": "100 STEEM",
+          "amount": <span>
+            0 STEEM
+          </span>,
           "from": "hellosteem",
           "memo": "Test Memo",
           "timestamp": "0",
@@ -195,7 +205,9 @@ ShallowWrapper {
                 className="UserWalletTransactions__received"
               >
                 + 
-                100 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -249,7 +261,9 @@ ShallowWrapper {
                 className="UserWalletTransactions__received"
               >
                 + 
-                100 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -279,7 +293,11 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <ReceiveTransaction
-    amount="100 STEEM"
+    amount={
+      <span>
+        0 STEEM
+      </span>
+    }
     from="hellosteem"
     memo="Test Memo"
     timestamp="0"

--- a/src/wallet/__tests__/__snapshots__/ReceiveTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/ReceiveTransaction.test.js.snap
@@ -51,10 +51,33 @@ ShallowWrapper {
       <span
         className="UserWalletTransactions__timestamp"
       >
-        <FormattedRelative
-          updateInterval={10000}
-          value="0Z"
-        />
+        <Tooltip
+          arrowPointAtCenter={false}
+          autoAdjustOverflow={true}
+          mouseEnterDelay={0.1}
+          mouseLeaveDelay={0.1}
+          placement="top"
+          prefixCls="ant-tooltip"
+          title={
+            <span>
+              <FormattedDate
+                value="0Z"
+              />
+               
+              <FormattedTime
+                value="0Z"
+              />
+            </span>
+          }
+          transitionName="zoom-big-fast"
+        >
+          <span>
+            <FormattedRelative
+              updateInterval={10000}
+              value="0Z"
+            />
+          </span>
+        </Tooltip>
       </span>
       <span
         className="UserWalletTransactions__memo"
@@ -107,10 +130,33 @@ ShallowWrapper {
         <span
           className="UserWalletTransactions__timestamp"
         >
-          <FormattedRelative
-            updateInterval={10000}
-            value="0Z"
-          />
+          <Tooltip
+            arrowPointAtCenter={false}
+            autoAdjustOverflow={true}
+            mouseEnterDelay={0.1}
+            mouseLeaveDelay={0.1}
+            placement="top"
+            prefixCls="ant-tooltip"
+            title={
+              <span>
+                <FormattedDate
+                  value="0Z"
+                />
+                 
+                <FormattedTime
+                  value="0Z"
+                />
+              </span>
+            }
+            transitionName="zoom-big-fast"
+          >
+            <span>
+              <FormattedRelative
+                updateInterval={10000}
+                value="0Z"
+              />
+            </span>
+          </Tooltip>
         </span>
         <span
           className="UserWalletTransactions__memo"
@@ -213,10 +259,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
             <span
               className="UserWalletTransactions__memo"
@@ -269,10 +338,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
             <span
               className="UserWalletTransactions__memo"

--- a/src/wallet/__tests__/__snapshots__/TransferTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/TransferTransaction.test.js.snap
@@ -43,7 +43,9 @@ ShallowWrapper {
           className="UserWalletTransactions__transfer"
         >
           - 
-          100 STEEM
+          <span>
+            0 STEEM
+          </span>
         </span>
       </div>
       <span
@@ -97,7 +99,9 @@ ShallowWrapper {
             className="UserWalletTransactions__transfer"
           >
             - 
-            100 STEEM
+            <span>
+              0 STEEM
+            </span>
           </span>
         </div>
         <span
@@ -123,7 +127,11 @@ ShallowWrapper {
       "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <TransferTransaction
-        amount="100 STEEM"
+        amount={
+          <span>
+            0 STEEM
+          </span>
+        }
         memo="Test Transfer Transaction"
         timestamp="0"
         to="hellosteem"
@@ -135,7 +143,9 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
-          "amount": "100 STEEM",
+          "amount": <span>
+            0 STEEM
+          </span>,
           "memo": "Test Transfer Transaction",
           "timestamp": "0",
           "to": "hellosteem",
@@ -195,7 +205,9 @@ ShallowWrapper {
                 className="UserWalletTransactions__transfer"
               >
                 - 
-                100 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -249,7 +261,9 @@ ShallowWrapper {
                 className="UserWalletTransactions__transfer"
               >
                 - 
-                100 STEEM
+                <span>
+                  0 STEEM
+                </span>
               </span>
             </div>
             <span
@@ -279,7 +293,11 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <TransferTransaction
-    amount="100 STEEM"
+    amount={
+      <span>
+        0 STEEM
+      </span>
+    }
     memo="Test Transfer Transaction"
     timestamp="0"
     to="hellosteem"

--- a/src/wallet/__tests__/__snapshots__/TransferTransaction.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/TransferTransaction.test.js.snap
@@ -51,10 +51,33 @@ ShallowWrapper {
       <span
         className="UserWalletTransactions__timestamp"
       >
-        <FormattedRelative
-          updateInterval={10000}
-          value="0Z"
-        />
+        <Tooltip
+          arrowPointAtCenter={false}
+          autoAdjustOverflow={true}
+          mouseEnterDelay={0.1}
+          mouseLeaveDelay={0.1}
+          placement="top"
+          prefixCls="ant-tooltip"
+          title={
+            <span>
+              <FormattedDate
+                value="0Z"
+              />
+               
+              <FormattedTime
+                value="0Z"
+              />
+            </span>
+          }
+          transitionName="zoom-big-fast"
+        >
+          <span>
+            <FormattedRelative
+              updateInterval={10000}
+              value="0Z"
+            />
+          </span>
+        </Tooltip>
       </span>
       <span
         className="UserWalletTransactions__memo"
@@ -107,10 +130,33 @@ ShallowWrapper {
         <span
           className="UserWalletTransactions__timestamp"
         >
-          <FormattedRelative
-            updateInterval={10000}
-            value="0Z"
-          />
+          <Tooltip
+            arrowPointAtCenter={false}
+            autoAdjustOverflow={true}
+            mouseEnterDelay={0.1}
+            mouseLeaveDelay={0.1}
+            placement="top"
+            prefixCls="ant-tooltip"
+            title={
+              <span>
+                <FormattedDate
+                  value="0Z"
+                />
+                 
+                <FormattedTime
+                  value="0Z"
+                />
+              </span>
+            }
+            transitionName="zoom-big-fast"
+          >
+            <span>
+              <FormattedRelative
+                updateInterval={10000}
+                value="0Z"
+              />
+            </span>
+          </Tooltip>
         </span>
         <span
           className="UserWalletTransactions__memo"
@@ -213,10 +259,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
             <span
               className="UserWalletTransactions__memo"
@@ -269,10 +338,33 @@ ShallowWrapper {
             <span
               className="UserWalletTransactions__timestamp"
             >
-              <FormattedRelative
-                updateInterval={10000}
-                value="0Z"
-              />
+              <Tooltip
+                arrowPointAtCenter={false}
+                autoAdjustOverflow={true}
+                mouseEnterDelay={0.1}
+                mouseLeaveDelay={0.1}
+                placement="top"
+                prefixCls="ant-tooltip"
+                title={
+                  <span>
+                    <FormattedDate
+                      value="0Z"
+                    />
+                     
+                    <FormattedTime
+                      value="0Z"
+                    />
+                  </span>
+                }
+                transitionName="zoom-big-fast"
+              >
+                <span>
+                  <FormattedRelative
+                    updateInterval={10000}
+                    value="0Z"
+                  />
+                </span>
+              </Tooltip>
             </span>
             <span
               className="UserWalletTransactions__memo"

--- a/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
@@ -59,7 +59,7 @@ ShallowWrapper {
           <FormattedNumber
             value={0}
           />
-           SP
+           SP 
         </span>
       </div>
     </div>
@@ -195,7 +195,7 @@ ShallowWrapper {
             <FormattedNumber
               value={0}
             />
-             SP
+             SP 
           </span>
         </div>
       </div>
@@ -391,7 +391,7 @@ ShallowWrapper {
                 <FormattedNumber
                   value={0}
                 />
-                 SP
+                 SP 
               </span>
             </div>
           </div>
@@ -527,7 +527,7 @@ ShallowWrapper {
                 <FormattedNumber
                   value={0}
                 />
-                 SP
+                 SP 
               </span>
             </div>
           </div>

--- a/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
@@ -60,6 +60,13 @@ ShallowWrapper {
             value={0}
           />
            SP 
+          <span>
+            (
+            <FormattedNumber
+              value={NaN}
+            />
+             SP)
+          </span>
         </span>
       </div>
     </div>
@@ -196,6 +203,13 @@ ShallowWrapper {
               value={0}
             />
              SP 
+            <span>
+              (
+              <FormattedNumber
+                value={NaN}
+              />
+               SP)
+            </span>
           </span>
         </div>
       </div>
@@ -392,6 +406,13 @@ ShallowWrapper {
                   value={0}
                 />
                  SP 
+                <span>
+                  (
+                  <FormattedNumber
+                    value={NaN}
+                  />
+                   SP)
+                </span>
               </span>
             </div>
           </div>
@@ -528,6 +549,13 @@ ShallowWrapper {
                   value={0}
                 />
                  SP 
+                <span>
+                  (
+                  <FormattedNumber
+                    value={NaN}
+                  />
+                   SP)
+                </span>
               </span>
             </div>
           </div>

--- a/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
@@ -41,32 +41,6 @@ ShallowWrapper {
       className="UserWalletSummary__item"
     >
       <i
-        className="iconfont icon-Dollar UserWalletSummary__icon"
-      />
-      <div
-        className="UserWalletSummary__label"
-      >
-        <FormattedMessage
-          defaultMessage="Steem Dollar"
-          id="steem_dollar"
-          values={Object {}}
-        />
-      </div>
-      <div
-        className="UserWalletSummary__value"
-      >
-        <span>
-          <FormattedNumber
-            value={NaN}
-          />
-           SBD
-        </span>
-      </div>
-    </div>
-    <div
-      className="UserWalletSummary__item"
-    >
-      <i
         className="iconfont icon-flashlight_fill UserWalletSummary__icon"
       />
       <div
@@ -86,6 +60,32 @@ ShallowWrapper {
             value={0}
           />
            SP
+        </span>
+      </div>
+    </div>
+    <div
+      className="UserWalletSummary__item"
+    >
+      <i
+        className="iconfont icon-Dollar UserWalletSummary__icon"
+      />
+      <div
+        className="UserWalletSummary__label"
+      >
+        <FormattedMessage
+          defaultMessage="Steem Dollar"
+          id="steem_dollar"
+          values={Object {}}
+        />
+      </div>
+      <div
+        className="UserWalletSummary__value"
+      >
+        <span>
+          <FormattedNumber
+            value={NaN}
+          />
+           SBD
         </span>
       </div>
     </div>
@@ -177,32 +177,6 @@ ShallowWrapper {
         className="UserWalletSummary__item"
       >
         <i
-          className="iconfont icon-Dollar UserWalletSummary__icon"
-        />
-        <div
-          className="UserWalletSummary__label"
-        >
-          <FormattedMessage
-            defaultMessage="Steem Dollar"
-            id="steem_dollar"
-            values={Object {}}
-          />
-        </div>
-        <div
-          className="UserWalletSummary__value"
-        >
-          <span>
-            <FormattedNumber
-              value={NaN}
-            />
-             SBD
-          </span>
-        </div>
-      </div>
-      <div
-        className="UserWalletSummary__item"
-      >
-        <i
           className="iconfont icon-flashlight_fill UserWalletSummary__icon"
         />
         <div
@@ -222,6 +196,32 @@ ShallowWrapper {
               value={0}
             />
              SP
+          </span>
+        </div>
+      </div>
+      <div
+        className="UserWalletSummary__item"
+      >
+        <i
+          className="iconfont icon-Dollar UserWalletSummary__icon"
+        />
+        <div
+          className="UserWalletSummary__label"
+        >
+          <FormattedMessage
+            defaultMessage="Steem Dollar"
+            id="steem_dollar"
+            values={Object {}}
+          />
+        </div>
+        <div
+          className="UserWalletSummary__value"
+        >
+          <span>
+            <FormattedNumber
+              value={NaN}
+            />
+             SBD
           </span>
         </div>
       </div>
@@ -373,32 +373,6 @@ ShallowWrapper {
             className="UserWalletSummary__item"
           >
             <i
-              className="iconfont icon-Dollar UserWalletSummary__icon"
-            />
-            <div
-              className="UserWalletSummary__label"
-            >
-              <FormattedMessage
-                defaultMessage="Steem Dollar"
-                id="steem_dollar"
-                values={Object {}}
-              />
-            </div>
-            <div
-              className="UserWalletSummary__value"
-            >
-              <span>
-                <FormattedNumber
-                  value={NaN}
-                />
-                 SBD
-              </span>
-            </div>
-          </div>
-          <div
-            className="UserWalletSummary__item"
-          >
-            <i
               className="iconfont icon-flashlight_fill UserWalletSummary__icon"
             />
             <div
@@ -418,6 +392,32 @@ ShallowWrapper {
                   value={0}
                 />
                  SP
+              </span>
+            </div>
+          </div>
+          <div
+            className="UserWalletSummary__item"
+          >
+            <i
+              className="iconfont icon-Dollar UserWalletSummary__icon"
+            />
+            <div
+              className="UserWalletSummary__label"
+            >
+              <FormattedMessage
+                defaultMessage="Steem Dollar"
+                id="steem_dollar"
+                values={Object {}}
+              />
+            </div>
+            <div
+              className="UserWalletSummary__value"
+            >
+              <span>
+                <FormattedNumber
+                  value={NaN}
+                />
+                 SBD
               </span>
             </div>
           </div>
@@ -509,32 +509,6 @@ ShallowWrapper {
             className="UserWalletSummary__item"
           >
             <i
-              className="iconfont icon-Dollar UserWalletSummary__icon"
-            />
-            <div
-              className="UserWalletSummary__label"
-            >
-              <FormattedMessage
-                defaultMessage="Steem Dollar"
-                id="steem_dollar"
-                values={Object {}}
-              />
-            </div>
-            <div
-              className="UserWalletSummary__value"
-            >
-              <span>
-                <FormattedNumber
-                  value={NaN}
-                />
-                 SBD
-              </span>
-            </div>
-          </div>
-          <div
-            className="UserWalletSummary__item"
-          >
-            <i
               className="iconfont icon-flashlight_fill UserWalletSummary__icon"
             />
             <div
@@ -554,6 +528,32 @@ ShallowWrapper {
                   value={0}
                 />
                  SP
+              </span>
+            </div>
+          </div>
+          <div
+            className="UserWalletSummary__item"
+          >
+            <i
+              className="iconfont icon-Dollar UserWalletSummary__icon"
+            />
+            <div
+              className="UserWalletSummary__label"
+            >
+              <FormattedMessage
+                defaultMessage="Steem Dollar"
+                id="steem_dollar"
+                values={Object {}}
+              />
+            </div>
+            <div
+              className="UserWalletSummary__value"
+            >
+              <span>
+                <FormattedNumber
+                  value={NaN}
+                />
+                 SBD
               </span>
             </div>
           </div>

--- a/src/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
@@ -82,6 +82,8 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <UserWalletTransactions
         currentUsername="hellosteem"
+        totalVestingFundSteem="0"
+        totalVestingShares="0"
         transactions={
           Array [
             Object {
@@ -115,6 +117,8 @@ ShallowWrapper {
         "context": Object {},
         "props": Object {
           "currentUsername": "hellosteem",
+          "totalVestingFundSteem": "0",
+          "totalVestingShares": "0",
           "transactions": Array [
             Object {
               "op": Array [
@@ -236,6 +240,8 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <UserWalletTransactions
     currentUsername="hellosteem"
+    totalVestingFundSteem="0"
+    totalVestingShares="0"
     transactions={
       Array [
         Object {


### PR DESCRIPTION
Fixes # .
- https://github.com/busyorg/busy/issues/935#issuecomment-340457245
- https://github.com/busyorg/busy/issues/930


Changes:
- Add SteemTrendingCharts to User Wallet Pages & display delegated SP
- Update order of Wallet Summary to "STEEM SP SBD"
- Update Tests & Snapshots
