### PR TITLE
Use getStateAsync instead of getAccountHistoryAsync for User Wallet Transactions

### DIFF
--- a/src/helpers/apiHelpers.js
+++ b/src/helpers/apiHelpers.js
@@ -118,9 +118,12 @@ const isWalletTransaction = actionType =>
   actionType === 'claim_reward_balance';
 
 export const getTransactionHistory = account =>
-  SteemAPI.getAccountHistoryAsync(account, -1, 2500).then(results =>
-    _.compact(
-      results.map((action) => {
+  SteemAPI.getStateAsync(`@${account}/transfers`).then((results) => {
+    const transferHistory = results.accounts[account]
+      ? results.accounts[account].transfer_history
+      : [];
+    return _.compact(
+      transferHistory.map((action) => {
         const actionDetails = action[1] || { op: [] };
         const actionType = actionDetails.op[0];
 
@@ -130,7 +133,8 @@ export const getTransactionHistory = account =>
 
         return null;
       }),
-    ),
+    );
+  },
   );
 
 export const getDynamicGlobalProperties = () => SteemAPI.getDynamicGlobalPropertiesAsync();

--- a/src/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
+++ b/src/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
@@ -11,38 +11,28 @@ ShallowWrapper {
   "node": <div
     className="UserWalletTransactions"
   >
-    <TransferTransaction
-      amount={
-        <span>
-          <FormattedNumber
-            maximumFractionDigits={3}
-            minimumFractionDigits={3}
-            value="100.000"
-          />
-           STEEM
-        </span>
+    <ReduxInfiniteScroll
+      className=""
+      containerHeight="100%"
+      elementIsScrollable={false}
+      hasMore={false}
+      holderType="div"
+      items={Array []}
+      loadMore={[Function]}
+      loader={
+        <div
+          style={
+            Object {
+              "textAlign": "center",
+            }
+          }
+        >
+          Loading...
+        </div>
       }
-      memo="transfer memo"
-      timestamp="0"
-      to=""
-    />
-    <PowerUpTransaction
-      amount={
-        <span>
-          <FormattedNumber
-            maximumFractionDigits={3}
-            minimumFractionDigits={3}
-            value="100.000"
-          />
-           SP
-        </span>
-      }
-      timestamp="0"
-    />
-  </div>,
-  "nodes": Array [
-    <div
-      className="UserWalletTransactions"
+      loadingMore={false}
+      showLoader={true}
+      threshold={100}
     >
       <TransferTransaction
         amount={
@@ -72,13 +62,71 @@ ShallowWrapper {
         }
         timestamp="0"
       />
+    </ReduxInfiniteScroll>
+  </div>,
+  "nodes": Array [
+    <div
+      className="UserWalletTransactions"
+    >
+      <ReduxInfiniteScroll
+        className=""
+        containerHeight="100%"
+        elementIsScrollable={false}
+        hasMore={false}
+        holderType="div"
+        items={Array []}
+        loadMore={[Function]}
+        loader={
+          <div
+            style={
+              Object {
+                "textAlign": "center",
+              }
+            }
+          >
+            Loading...
+          </div>
+        }
+        loadingMore={false}
+        showLoader={true}
+        threshold={100}
+      >
+        <TransferTransaction
+          amount={
+            <span>
+              <FormattedNumber
+                maximumFractionDigits={3}
+                minimumFractionDigits={3}
+                value="100.000"
+              />
+               STEEM
+            </span>
+          }
+          memo="transfer memo"
+          timestamp="0"
+          to=""
+        />
+        <PowerUpTransaction
+          amount={
+            <span>
+              <FormattedNumber
+                maximumFractionDigits={3}
+                minimumFractionDigits={3}
+                value="100.000"
+              />
+               SP
+            </span>
+          }
+          timestamp="0"
+        />
+      </ReduxInfiniteScroll>
     </div>,
   ],
   "options": Object {},
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 2,
+      "_compositeType": 0,
       "_context": Object {},
       "_currentElement": <UserWalletTransactions
         currentUsername="hellosteem"
@@ -88,20 +136,20 @@ ShallowWrapper {
           Array [
             Object {
               "op": Array [
-                "transfer_to_vesting",
+                "transfer",
                 Object {
                   "amount": "100 STEEM",
+                  "from": "hellosteem1",
+                  "memo": "transfer memo",
                 },
               ],
               "timestamp": "0",
             },
             Object {
               "op": Array [
-                "transfer",
+                "transfer_to_vesting",
                 Object {
                   "amount": "100 STEEM",
-                  "from": "hellosteem1",
-                  "memo": "transfer memo",
                 },
               ],
               "timestamp": "0",
@@ -112,23 +160,15 @@ ShallowWrapper {
       "_debugID": 1,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance": StatelessComponent {
+      "_instance": UserWalletTransactions {
         "_reactInternalInstance": [Circular],
         "context": Object {},
+        "handleNextPage": [Function],
         "props": Object {
           "currentUsername": "hellosteem",
           "totalVestingFundSteem": "0",
           "totalVestingShares": "0",
           "transactions": Array [
-            Object {
-              "op": Array [
-                "transfer_to_vesting",
-                Object {
-                  "amount": "100 STEEM",
-                },
-              ],
-              "timestamp": "0",
-            },
             Object {
               "op": Array [
                 "transfer",
@@ -140,10 +180,21 @@ ShallowWrapper {
               ],
               "timestamp": "0",
             },
+            Object {
+              "op": Array [
+                "transfer_to_vesting",
+                Object {
+                  "amount": "100 STEEM",
+                },
+              ],
+              "timestamp": "0",
+            },
           ],
         },
         "refs": Object {},
-        "state": null,
+        "state": Object {
+          "visibleItems": 10,
+        },
         "updater": Object {
           "enqueueCallback": [Function],
           "enqueueCallbackInternal": [Function],
@@ -165,67 +216,115 @@ ShallowWrapper {
         "_currentElement": <div
           className="UserWalletTransactions"
         >
-          <TransferTransaction
-            amount={
-              <span>
-                <FormattedNumber
-                  maximumFractionDigits={3}
-                  minimumFractionDigits={3}
-                  value="100.000"
-                />
-                 STEEM
-              </span>
+          <ReduxInfiniteScroll
+            className=""
+            containerHeight="100%"
+            elementIsScrollable={false}
+            hasMore={false}
+            holderType="div"
+            items={Array []}
+            loadMore={[Function]}
+            loader={
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Loading...
+              </div>
             }
-            memo="transfer memo"
-            timestamp="0"
-            to=""
-          />
-          <PowerUpTransaction
-            amount={
-              <span>
-                <FormattedNumber
-                  maximumFractionDigits={3}
-                  minimumFractionDigits={3}
-                  value="100.000"
-                />
-                 SP
-              </span>
-            }
-            timestamp="0"
-          />
+            loadingMore={false}
+            showLoader={true}
+            threshold={100}
+          >
+            <TransferTransaction
+              amount={
+                <span>
+                  <FormattedNumber
+                    maximumFractionDigits={3}
+                    minimumFractionDigits={3}
+                    value="100.000"
+                  />
+                   STEEM
+                </span>
+              }
+              memo="transfer memo"
+              timestamp="0"
+              to=""
+            />
+            <PowerUpTransaction
+              amount={
+                <span>
+                  <FormattedNumber
+                    maximumFractionDigits={3}
+                    minimumFractionDigits={3}
+                    value="100.000"
+                  />
+                   SP
+                </span>
+              }
+              timestamp="0"
+            />
+          </ReduxInfiniteScroll>
         </div>,
         "_debugID": 2,
         "_renderedOutput": <div
           className="UserWalletTransactions"
         >
-          <TransferTransaction
-            amount={
-              <span>
-                <FormattedNumber
-                  maximumFractionDigits={3}
-                  minimumFractionDigits={3}
-                  value="100.000"
-                />
-                 STEEM
-              </span>
+          <ReduxInfiniteScroll
+            className=""
+            containerHeight="100%"
+            elementIsScrollable={false}
+            hasMore={false}
+            holderType="div"
+            items={Array []}
+            loadMore={[Function]}
+            loader={
+              <div
+                style={
+                  Object {
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Loading...
+              </div>
             }
-            memo="transfer memo"
-            timestamp="0"
-            to=""
-          />
-          <PowerUpTransaction
-            amount={
-              <span>
-                <FormattedNumber
-                  maximumFractionDigits={3}
-                  minimumFractionDigits={3}
-                  value="100.000"
-                />
-                 SP
-              </span>
-            }
-            timestamp="0"
-          />
+            loadingMore={false}
+            showLoader={true}
+            threshold={100}
+          >
+            <TransferTransaction
+              amount={
+                <span>
+                  <FormattedNumber
+                    maximumFractionDigits={3}
+                    minimumFractionDigits={3}
+                    value="100.000"
+                  />
+                   STEEM
+                </span>
+              }
+              memo="transfer memo"
+              timestamp="0"
+              to=""
+            />
+            <PowerUpTransaction
+              amount={
+                <span>
+                  <FormattedNumber
+                    maximumFractionDigits={3}
+                    minimumFractionDigits={3}
+                    value="100.000"
+                  />
+                   SP
+                </span>
+              }
+              timestamp="0"
+            />
+          </ReduxInfiniteScroll>
         </div>,
       },
       "_renderedNodeType": 0,
@@ -246,20 +345,20 @@ ShallowWrapper {
       Array [
         Object {
           "op": Array [
-            "transfer_to_vesting",
+            "transfer",
             Object {
               "amount": "100 STEEM",
+              "from": "hellosteem1",
+              "memo": "transfer memo",
             },
           ],
           "timestamp": "0",
         },
         Object {
           "op": Array [
-            "transfer",
+            "transfer_to_vesting",
             Object {
               "amount": "100 STEEM",
-              "from": "hellosteem1",
-              "memo": "transfer memo",
             },
           ],
           "timestamp": "0",


### PR DESCRIPTION
So I've been thinking about this, right now we getAccountHistoryAsync, but when we use that, we have to filter through every single user action just to get the wallet transactions. So even though we get 2500, sometimes it won't be all of the user's wallet transactions... so how would we know when the user has more wallet transactions?

Also for this, I tried to use React Infinite: (https://github.com/seatgeek/react-infinite) 
* but it has issues when rendering element sizes of dynamic heights (https://github.com/seatgeek/react-infinite/issues/231)

After trying to get React Infinite to work, I settled on using what we currently have, `ReduxInfiniteScroll`.

Let me know your thoughts @Sekhmet @bonustrack  

Fixes # 
https://github.com/busyorg/busy/issues/928

Changes:
- Use getStateAsync instead of getAccountHistoryAsync to get user transaction history

