### PR TITLE
Center UserHeader to match steemit cover picture

### DIFF
--- a/src/components/UserHeader.less
+++ b/src/components/UserHeader.less
@@ -35,6 +35,7 @@
   display: flex;
   margin: 0 auto;
   max-width: 1011px;
+  justify-content: center;
   padding: 30px 0;
 }
 

--- a/src/components/UserHeaderLoading.less
+++ b/src/components/UserHeaderLoading.less
@@ -8,6 +8,7 @@
     display: flex;
     margin: 0 auto;
     max-width: 1011px;
+    justify-content: center;
     padding: 30px 0;
   }
 


### PR DESCRIPTION
# Before Fix

![screen shot 2017-11-01 at 4 10 50 pm](https://user-images.githubusercontent.com/5067716/32295314-498b1d00-bf1f-11e7-9515-95f1b8e16e95.png)


# After Fix
![screen shot 2017-11-01 at 4 06 33 pm](https://user-images.githubusercontent.com/5067716/32295268-227f8a20-bf1f-11e7-8a97-ddd79b2765cf.png)

Fixes # .
https://github.com/busyorg/busy/issues/910

Changes:
- add flex property - `justify content: center` to UserHeader contents
