### PR TITLE
add page_forbidden and page_forbidden_message in translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,5 +198,7 @@
   "received_from": "Received from {username}",
   "claim_rewards": "Claim rewards ",
   "powered_up": "Powered up ",
-  "market": "Market"
+  "market": "Market",
+  "page_forbidden": "Page Requires Authentication",
+  "page_forbidden_message": "Oops! Looks like you need to login to use this page."
 }


### PR DESCRIPTION
Fixes #  https://github.com/busyorg/busy/issues/974

Changes:
- page_forbidden and page_forbidden_message referenced in `Error401 component`(https://github.com/busyorg/busy/blob/new-design/src/statics/Error401.js) are both missing translations