### PR TITLE
Update TopicSelector styles

### DIFF
--- a/src/components/TopicSelector.js
+++ b/src/components/TopicSelector.js
@@ -53,7 +53,9 @@ class TopicSelector extends React.Component {
             )}
         </div>
         <div className="TopicSelector__sort">
-          <FormattedMessage id="sort_by" defaultMessage="Sort by" />
+          <span className="TopicSelector__sort__title">
+            <FormattedMessage id="sort_by" defaultMessage="Sort by" />
+          </span>
           <Popover
             trigger="click"
             visible={popoverVisible}

--- a/src/components/TopicSelector.less
+++ b/src/components/TopicSelector.less
@@ -3,6 +3,7 @@
 .TopicSelector {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 16px;
   padding: 0 @mobile-padding;
 
@@ -20,11 +21,18 @@
 
   &__sort {
     color: #99aab5;
+    text-align: right;
+
+    span:first-of-type {
+      display: inline-block;
+      white-space: nowrap;
+    }
 
     &__current {
       cursor: pointer;
       margin-left: 8px;
       font-weight: 500;
+      white-space: nowrap;
 
       & > .iconfont {
         margin-left: 4px;

--- a/src/components/TopicSelector.less
+++ b/src/components/TopicSelector.less
@@ -23,7 +23,7 @@
     color: #99aab5;
     text-align: right;
 
-    span:first-of-type {
+    &__title {
       display: inline-block;
       white-space: nowrap;
     }

--- a/src/stories/__snapshots__/stories.test.js.snap
+++ b/src/stories/__snapshots__/stories.test.js.snap
@@ -2792,8 +2792,12 @@ exports[`Storyshots Topic selector Topic selector 1`] = `
     <div
       className="TopicSelector__sort"
     >
-      <span>
-        Sort by
+      <span
+        className="TopicSelector__sort__title"
+      >
+        <span>
+          Sort by
+        </span>
       </span>
       <span
         className="TopicSelector__sort__current"


### PR DESCRIPTION
Fixes #988.

This changes how TopicSelector behaves on smaller screens.
- TopicSelector items are now aligned in center
- "Sort by" and current sort now have white-space set to nowrap to prevent
breaking it.
- "Sort by" and current sort now have display set to inline-block to
cause them to split to two lines if there is no room.

**Before**:
![image](https://user-images.githubusercontent.com/1968722/32371940-23e779e8-c093-11e7-8ac2-5d6baa53cda7.png)
**After**:
![image](https://user-images.githubusercontent.com/1968722/32371964-37af2c00-c093-11e7-87f2-25a9671b3e37.png)