### PR TITLE
Add babel-polyfill

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
@@ -34,9 +35,9 @@ if (process.env.SENTRY_PUBLIC_DSN) {
 }
 
 if (
-  process.env.STEEMCONNECT_CLIENT_ID
-  && process.env.STEEMCONNECT_REDIRECT_URL
-  && process.env.STEEMCONNECT_HOST
+  process.env.STEEMCONNECT_CLIENT_ID &&
+  process.env.STEEMCONNECT_REDIRECT_URL &&
+  process.env.STEEMCONNECT_HOST
 ) {
   steemconnect.init({
     app: process.env.STEEMCONNECT_CLIENT_ID,
@@ -62,19 +63,13 @@ const render = (Component) => {
   ReactDOM.render(
     <Provider store={store}>
       <LocaleProvider locale={enUS}>
-        {process.env.NODE_ENV !== 'production' ?
+        {process.env.NODE_ENV !== 'production' ? (
           <AppContainer>
-            <Component
-              history={history}
-              onUpdate={logPageView}
-            />
+            <Component history={history} onUpdate={logPageView} />
           </AppContainer>
-          :
-          <Component
-            history={history}
-            onUpdate={logPageView}
-          />
-        }
+        ) : (
+          <Component history={history} onUpdate={logPageView} />
+        )}
       </LocaleProvider>
     </Provider>,
     document.getElementById('app'),
@@ -85,5 +80,7 @@ render(AppHost);
 
 // Hot Module Replacement API
 if (module.hot) {
-  module.hot.accept('./AppHost', () => { render(AppHost); });
+  module.hot.accept('./AppHost', () => {
+    render(AppHost);
+  });
 }


### PR DESCRIPTION
Fixes #845

This solves problem with Busy not working in IE11. It works on production builds, not on development builds.
Supporting IE < 11 is more problematic, because of the lack of Web Cryptography API. I don't think we should try to make it work on IE 10 and below as it is not used anymore, insecure and using polyfills for something as important as cryptography might introduce vulnerabilities.
Changes:
- Add `babel-polyfill` to the entry of the app.
