### PR TITLE
Add Save Translation

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,7 @@
   "hero": "Ensuring compensation for the creators of value",
   "search": "Search",
   "search_placeholder": "Search...",
+  "save": "Save",
   "saved": "Saved",
   "cancel": "Cancel",
   "confirm": "Confirm",

--- a/src/settings/Settings.js
+++ b/src/settings/Settings.js
@@ -252,9 +252,13 @@ export default class Settings extends React.Component {
                     {languageOptions}
                   </Select>
                 </div>
-                <Action primary loading={loading} text="Save" onClick={this.handleSave} />
-              </div>
-            )}
+                <Action
+                  primary
+                  loading={loading}
+                  text={this.props.intl.formatMessage({ id: 'save', defaultMessage: 'Save' })}
+                  onClick={this.handleSave}
+                />
+              </div>)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
* https://github.com/busyorg/busy/issues/987

Fixes # .
https://github.com/busyorg/busy/issues/987
Changes:
- Use intl format for "Save" text in User Settings page