### PR TITLE
Add empty check for cancel transfer savings transaction

### DIFF
--- a/src/wallet/UserWalletTransactions.js
+++ b/src/wallet/UserWalletTransactions.js
@@ -37,6 +37,10 @@ class UserWalletTransactions extends React.Component {
   }
 
   getFormattedTransactionAmount = (amount, currency) => {
+    if (_.isEmpty(amount)) {
+      return null;
+    }
+
     const transaction = amount.split(' ');
     const transactionAmount = parseFloat(transaction[0]);
     const transactionCurrency = currency || transaction[1];


### PR DESCRIPTION
Fixes #1000
- Users such as @inoue, weren't able to get their wallet page to load (https://busy.org/@inoue/transfers)

Changes:
- add isEmpty check to `getFormattedTransactionAmount` in `UserWalletTransactions` since `cancel_transfer_savings` action doesn't include the amount param

