### PR TITLE
Merge previous jsonMetadata when saving post

### DIFF
--- a/src/post/Write/Write.js
+++ b/src/post/Write/Write.js
@@ -187,11 +187,20 @@ class Write extends React.Component {
 
     if (this.state.isUpdating) data.isUpdating = this.state.isUpdating;
 
-    const metaData = {
+    let metaData = {
       community: 'busy',
       app: `busy/${version}`,
       format: 'markdown',
     };
+
+    // Merging jsonMetadata makes sure that users don't lose any metadata when they edit post using
+    // Busy (like video data from DTube)
+    if (this.props.draftPosts[this.draftId] && this.props.draftPosts[this.draftId].jsonMetadata) {
+      metaData = {
+        ...metaData,
+        ...this.props.draftPosts[this.draftId].jsonMetadata,
+      };
+    }
 
     if (tags.length) {
       metaData.tags = tags;


### PR DESCRIPTION
Fixes #914 

Changes:
- If draft has metadata already it will be merged into new metadata. Topics, images, users, and links will be updated anyway to match current content.
