### PR TITLE
Display image preview for short posts with image

### DIFF
--- a/src/components/Story/StoryHelper.js
+++ b/src/components/Story/StoryHelper.js
@@ -32,6 +32,7 @@ const isPostWithEmbedBeforeFirstHalf = tagPositions => postWithAnEmbed(tagPositi
 
 export {
   getPositions,
+  postWithPicture,
   postWithAnEmbed,
   isPostStartsWithAPicture,
   isPostStartsWithAnEmbed,

--- a/src/components/Story/StoryPreview.js
+++ b/src/components/Story/StoryPreview.js
@@ -8,6 +8,7 @@ import { jsonParse } from '../../helpers/formatter';
 import { image } from '../../vendor/steemitLinks';
 import {
   getPositions,
+  postWithPicture,
   postWithAnEmbed,
   isPostStartsWithAPicture,
   isPostStartsWithAnEmbed,
@@ -63,6 +64,9 @@ const StoryPreview = ({ post }) => {
 
   if (hasVideo) {
     bodyData.push(preview.embed());
+    bodyData.push(preview.text());
+  } else if (htmlBody.length <= 1500 && postWithPicture(tagPositions, 100)) {
+    bodyData.push(preview.image());
     bodyData.push(preview.text());
   } else if (htmlBody.length <= 1500 && postWithAnEmbed(tagPositions, 100)) {
     bodyData.push(preview.embed());


### PR DESCRIPTION
Fixes #1012.

Changes:
- Show image preview if post is short and has an image (similar to embed).
