### PR TITLE
Fix reputation wrap issue on mobile #842

### DIFF
--- a/src/components/UserHeader.less
+++ b/src/components/UserHeader.less
@@ -47,6 +47,11 @@
 
   .UserHeader__user {
     padding-bottom: 20px;
+    margin: 0 !important;
+
+    &__username {
+      font-size: 28px !important;
+    }
   }
 
   .UserHeader__row {


### PR DESCRIPTION
Fixes #842 .

Changes:
- made `.UserHeader__user` to have `margin: 0 !important;` on small screens. This margin has no relevance on small screens, since the text is center aligned and has no elements on the sides.
- decreased font size for `.UserHeader__user__username` to `28px` on small screens

Observations:
The `!important` was necessary because some media queries were defined before normal style in `UserHeader.less`. Normally media queries are defined after the normal style(non-media). In the present case the normal style would override the media queries, therefore `!important` was needed.

I wanted to move the media queries at the bottom of the file, so that the `!important` will not be needed, but wasn't sure if the reason for this would be clear enough.

In case this is wanted, it can be easily changed.
