### PR TITLE
Fix StoryFull actions: save and edit

### DIFF
--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -84,13 +84,13 @@ class StoryFull extends React.Component {
         this.props.onFollowClick(this.props.post);
         break;
       case 'save':
-        this.props.onSaveClick();
+        this.props.onSaveClick(this.props.post);
         break;
       case 'report':
         this.props.onReportClick(this.props.post);
         break;
       case 'edit':
-        this.props.onEditClick();
+        this.props.onEditClick(this.props.post);
         break;
       default:
     }


### PR DESCRIPTION
Fixes #1010.

Save and edit actions missed post as argument causing those
two functions to break.

Changes:
- Now post is passed as argument to `onSaveClick` and `onEditClick`