### PR TITLE
Changes Sidenav link color on hover #950

### DIFF
--- a/src/components/Navigation/Sidenav.less
+++ b/src/components/Navigation/Sidenav.less
@@ -7,6 +7,10 @@
       color: #99aab5;
       font-weight: 500;
 
+      &:hover {
+        color: @purple;
+      }
+
       &:focus {
         text-decoration: none;
       }


### PR DESCRIPTION
Fixes #950 .

Changes:
- the left menu (`.Sidenav`) link color changes on hover. `@purple` is set as color for '.Sidenav>li>a:hover'