### PR TITLE
Handle deleted posts

### DIFF
--- a/src/components/Story/StoryDeleted.js
+++ b/src/components/Story/StoryDeleted.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import './StoryDeleted.less';
+
+const StoryDeleted = () => (
+  <div className="StoryDeleted">
+    <h3>
+      <FormattedMessage id="post_deleted" defaultMessage="This post has been deleted" />
+    </h3>
+  </div>
+);
+
+export default StoryDeleted;

--- a/src/components/Story/StoryDeleted.less
+++ b/src/components/Story/StoryDeleted.less
@@ -1,8 +1,10 @@
+@import (reference) "../../styles/custom.less";
+
 .StoryDeleted {
   text-align: center;
   margin: 32px 0;
-  
+
   h3 {
-    color: #99aab5;
+    color: @blue-botticelli;
   }
 }

--- a/src/components/Story/StoryDeleted.less
+++ b/src/components/Story/StoryDeleted.less
@@ -1,0 +1,8 @@
+.StoryDeleted {
+  text-align: center;
+  margin: 32px 0;
+  
+  h3 {
+    color: #99aab5;
+  }
+}

--- a/src/components/Story/StoryFull.js
+++ b/src/components/Story/StoryFull.js
@@ -12,7 +12,9 @@ import { Link } from 'react-router-dom';
 import { Tag, Icon, Popover, Tooltip } from 'antd';
 import Lightbox from 'react-image-lightbox';
 import { formatter } from 'steem';
+import { isPostDeleted } from '../../helpers/postHelpers';
 import Body from './Body';
+import StoryDeleted from './StoryDeleted';
 import StoryFooter from '../StoryFooter/StoryFooter';
 import Avatar from '../Avatar';
 import Topic from '../Button/Topic';
@@ -232,6 +234,33 @@ class StoryFull extends React.Component {
       </PopoverMenuItem>,
     ];
 
+    let content = null;
+    if (isPostDeleted(post)) {
+      content = <StoryDeleted />;
+    } else {
+      content = (
+        <div
+          role="presentation"
+          ref={(div) => {
+            this.contentDiv = div;
+          }}
+          onClick={this.handleContentClick}
+        >
+          {_.has(video, 'content.videohash') &&
+            _.has(video, 'info.snaphash') && (
+              <video
+                controls
+                src={`https://ipfs.io/ipfs/${video.content.videohash}`}
+                poster={`https://ipfs.io/ipfs/${video.info.snaphash}`}
+              >
+                <track kind="captions" />
+              </video>
+            )}
+          <Body full body={post.body} json_metadata={post.json_metadata} />
+        </div>
+      );
+    }
+
     return (
       <div className="StoryFull">
         {replyUI}
@@ -286,25 +315,7 @@ class StoryFull extends React.Component {
             <i className="iconfont icon-more StoryFull__header__more" />
           </Popover>
         </div>
-        <div
-          role="presentation"
-          ref={(div) => {
-            this.contentDiv = div;
-          }}
-          onClick={this.handleContentClick}
-        >
-          {_.has(video, 'content.videohash') &&
-            _.has(video, 'info.snaphash') && (
-              <video
-                controls
-                src={`https://ipfs.io/ipfs/${video.content.videohash}`}
-                poster={`https://ipfs.io/ipfs/${video.info.snaphash}`}
-              >
-                <track kind="captions" />
-              </video>
-            )}
-          <Body full body={post.body} json_metadata={post.json_metadata} />
-        </div>
+        {content}
         {open && (
           <Lightbox
             mainSrc={images[index]}

--- a/src/feed/Feed.js
+++ b/src/feed/Feed.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import ReduxInfiniteScroll from 'redux-infinite-scroll';
 import _ from 'lodash';
 import { getHasDefaultSlider } from '../helpers/user';
+import { isPostDeleted } from '../helpers/postHelpers';
 import * as bookmarkActions from '../bookmarks/bookmarksActions';
 import * as reblogActions from '../app/Reblog/reblogActions';
 import * as postActions from '../post/postActions';
@@ -160,6 +161,8 @@ export default class Feed extends React.Component {
             isReported: userVote.percent < 0,
             userFollowed: followingList.includes(post.author),
           };
+
+          if (isPostDeleted(post)) return null;
 
           return (
             <Story

--- a/src/helpers/postHelpers.js
+++ b/src/helpers/postHelpers.js
@@ -1,0 +1,3 @@
+export const isPostDeleted = post => post.title === 'deleted' && post.body === 'deleted';
+
+export default null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -60,6 +60,7 @@
   "post_reply_title": "This is a reply to: {title}",
   "post_reply_show_original_post": "Show original post",
   "post_reply_show_parent_discussion": "Show parent discussion",
+  "post_deleted": "This post has been deleted",
   "comment": "Comment",
   "comment_placeholder": "Write a comment",
   "comment_collapsed": "Comment collapsed",


### PR DESCRIPTION
Fixes #906.

Changes:
- Add `isPostDeleted` helper that detects if post is deleted (`body` and `title` equal to `deleted`).
- Hide deleted posts in feed.
- Display `StoryDeleted` component instead of content if post has been disabled in single post view.

![image](https://user-images.githubusercontent.com/1968722/32414741-f33622ee-c22d-11e7-885f-bfc5b96ce46a.png)
