### PR TITLE
Improve votes sorting

### DIFF
--- a/src/helpers/sortHelpers.js
+++ b/src/helpers/sortHelpers.js
@@ -34,10 +34,6 @@ export const sortComments = (comments, sortType = 'BEST') => {
   }
 };
 
-export const sortVotes = (a, b) => {
-  const aShares = parseInt(a.rshares, 10);
-  const bShares = parseInt(b.rshares, 10);
-  return bShares - aShares;
-};
+export const sortVotes = (a, b) => b.rshares - a.rshares;
 
 export default null;


### PR DESCRIPTION
Changes:
1. Remove `parseInt` from `sortVotes`.
Using implicit conversion is faster (~20 times faster). This results
in ~1300ms faster render when scrolling in feed and loading new posts twice:
Before:
![image](https://user-images.githubusercontent.com/1968722/32419084-d0df9620-c274-11e7-8c9b-6d7253f63adb.png)
After:
![image](https://user-images.githubusercontent.com/1968722/32419086-d6e2cd76-c274-11e7-9824-2741898725b4.png)