### PR TITLE
Update current auth user, when claim rewards is clicked

### DIFF
--- a/src/auth/authActions.js
+++ b/src/auth/authActions.js
@@ -1,8 +1,10 @@
 import Promise from 'bluebird';
 import steemConnect from 'sc2-sdk';
 import Cookie from 'js-cookie';
+import { getAccountWithFollowingCount } from '../helpers/apiHelpers';
 import { getFollowing } from '../user/userActions';
 import { initPushpad } from '../helpers/pushpadHelper';
+import { createAsyncActionType } from '../helpers/stateHelpers';
 
 Promise.promisifyAll(steemConnect);
 
@@ -20,6 +22,8 @@ export const LOGOUT = '@auth/LOGOUT';
 export const LOGOUT_START = '@auth/LOGOUT_START';
 export const LOGOUT_ERROR = '@auth/LOGOUT_ERROR';
 export const LOGOUT_SUCCESS = '@auth/LOGOUT_SUCCESS';
+
+export const UPDATE_AUTH_USER = createAsyncActionType('@auth/UPDATE_AUTH_USER');
 
 export const login = () => (dispatch) => {
   dispatch({
@@ -52,3 +56,10 @@ export const logout = () => (dispatch) => {
     },
   });
 };
+
+export const updateAuthUser = username => dispatch => dispatch({
+  type: UPDATE_AUTH_USER.ACTION,
+  payload: {
+    promise: getAccountWithFollowingCount(username),
+  },
+});

--- a/src/auth/authReducer.js
+++ b/src/auth/authReducer.js
@@ -58,6 +58,15 @@ export default (state = initialState, action) => {
         loaded: true,
         user: {},
       };
+    case types.UPDATE_AUTH_USER.SUCCESS:
+      return {
+        ...state,
+        user: {
+          ...state.user,
+          ...action.payload,
+        },
+        loadingUpdateAuthUser: false,
+      };
     default:
       return state;
   }

--- a/src/wallet/ClaimRewardsBlock.js
+++ b/src/wallet/ClaimRewardsBlock.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { injectIntl, FormattedMessage, FormattedNumber } from 'react-intl';
 import { getAuthenticatedUser } from '../reducers';
 import { getUserAccountHistory } from './walletActions';
+import { updateAuthUser } from '../auth/authActions';
 import Action from '../components/Button/Action';
 import './ClaimRewardsBlock.less';
 
@@ -16,6 +17,7 @@ import './ClaimRewardsBlock.less';
   }),
   {
     getUserAccountHistory,
+    updateAuthUser,
   },
 )
 class ClaimRewardsBlock extends Component {
@@ -23,6 +25,7 @@ class ClaimRewardsBlock extends Component {
     user: PropTypes.shape(),
     intl: PropTypes.shape().isRequired,
     getUserAccountHistory: PropTypes.func.isRequired,
+    updateAuthUser: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -52,6 +55,7 @@ class ClaimRewardsBlock extends Component {
             rewardClaimed: true,
           });
           this.props.getUserAccountHistory(name);
+          this.props.updateAuthUser(name);
         } else {
           this.setState({
             loading: false,


### PR DESCRIPTION
Fixes # https://github.com/busyorg/busy/issues/1034.

Changes:
- Add updateAuthUser action, and call it when rewards has been successfully claimed
