### PR TITLE
Add flex-wrap to Comments Header

### DIFF
--- a/src/components/Comments/Comments.less
+++ b/src/components/Comments/Comments.less
@@ -7,6 +7,7 @@
 
   &__header {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     padding-bottom: 16px;


### PR DESCRIPTION
Fixes https://github.com/busyorg/busy/issues/1037

Changes:
- Add flex-wrap to Comments Header

# Before:
![image](https://user-images.githubusercontent.com/5067716/32577098-d1967302-c4a6-11e7-9a9a-1fe8c6149b8a.png)

# After:
![screen shot 2017-11-08 at 4 58 03 pm](https://user-images.githubusercontent.com/5067716/32577105-d889a184-c4a6-11e7-8704-8e5480044873.png)
