### PR TITLE
Add styles to fix table in Post

### DIFF
--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -114,8 +114,8 @@
 
   table {
     width: 100%;
-    display: table;
-    table-layout: fixed;
+    display: block;
+    overflow: auto;
 
     tr > th {
       text-align: left;

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -115,8 +115,7 @@
   table {
     width: 100%;
     display: table;
-    border-collapse: collapse;
-    border-spacing: 0;
+    table-layout: fixed;
 
     tr > th {
       text-align: left;

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -126,6 +126,7 @@
       padding: 4px 12px;
       word-wrap: break-word;
       vertical-align: middle;
+      word-break: normal;
     }
 
     tr:nth-child(even) {

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -115,6 +115,8 @@
   table {
     width: 100%;
     display: table;
+    border-collapse: collapse;
+    border-spacing: 0;
 
     tr > th {
       text-align: left;


### PR DESCRIPTION
See here: `/report/@hien-tran/the-best-steem-blockchain-apps-updated-on-09th-november`

Fixes #1058

Changes:
- Add word-break: normal styles to all td/th table tags
- Add display: block to table so we can view the overflow when it gets too large for the post
