### PR TITLE
Fixed interesting people long username issue

### DIFF
--- a/src/components/Sidebar/User.less
+++ b/src/components/Sidebar/User.less
@@ -34,6 +34,7 @@
 }
 
 .User__name {
+  width:100px;
   margin-left: 8px;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
Fixes #840 .

Changes:
- added `width:100px;` to the Sidebar `.User__name` so that when there is a long username there will be an overflow and the existing `text-overflow: ellipsis;` would work

Here is how the **Interesting People** section looks with this PR:

![interesting-1](https://user-images.githubusercontent.com/32915194/32810722-9389ed14-c99c-11e7-846d-4cdd310bdbae.png)

I changed the language to czech as per @espoem's screenshots.

![interesting-2](https://user-images.githubusercontent.com/32915194/32810723-93bcc95a-c99c-11e7-8cc2-3ec7b6b4145d.png)

