### PR TITLE
Fix for logout localized text wrap issue

### DIFF
--- a/src/components/PopoverMenu/PopoverMenuItem.less
+++ b/src/components/PopoverMenu/PopoverMenuItem.less
@@ -17,6 +17,10 @@
     &[disabled] {
       color: #c2ccd3 !important;
     }
+
+    & > span {
+      white-space: nowrap;
+    }
   }
 
   &--bold {


### PR DESCRIPTION
Fixes #1032 .

Changes:
- made the menu items to not wrap text

I tested this and as @espoem said when reporting the issue, this can only be replicated when resizing the page.
If you refresh the page at any window width the text will look good. Therefore the solution for this is as simple as forcing the text to not wrap at all.
