### PR TITLE
Fixed PropType warning and show all vote stats in modal

### DIFF
--- a/src/components/Reactions/ReactionsList.js
+++ b/src/components/Reactions/ReactionsList.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
 import InfiniteSroll from 'react-infinite-scroller';
 import { take } from 'lodash';
-import { FormattedNumber } from 'react-intl';
 import UserCard from '../UserCard';
-import USDDisplay from '../Utils/USDDisplay';
 import './ReactionsList.less';
 
 export default class UserList extends React.Component {
@@ -41,16 +39,8 @@ export default class UserList extends React.Component {
               <UserCard
                 key={vote.voter}
                 username={vote.voter}
-                alt={vote.rshares * ratio > 0.01 &&
-                  <span>
-                    <USDDisplay value={vote.rshares * ratio} />
-                    <span className="ReactionsList__bullet" />
-                    <FormattedNumber
-                      style="percent" // eslint-disable-line react/style-prop-object
-                      value={vote.percent / 10000}
-                    />
-                  </span>
-                }
+                voteUsd={vote.rshares * ratio}
+                votePercent={vote.percent / 10000}
               />
             ))}
           </div>

--- a/src/components/Reactions/ReactionsList.js
+++ b/src/components/Reactions/ReactionsList.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { Scrollbars } from 'react-custom-scrollbars';
 import InfiniteSroll from 'react-infinite-scroller';
 import { take } from 'lodash';
+import { FormattedNumber } from 'react-intl';
 import UserCard from '../UserCard';
+import USDDisplay from '../Utils/USDDisplay';
 import './ReactionsList.less';
 
 export default class UserList extends React.Component {
@@ -39,8 +41,16 @@ export default class UserList extends React.Component {
               <UserCard
                 key={vote.voter}
                 username={vote.voter}
-                voteUsd={vote.rshares * ratio}
-                votePercent={vote.percent / 10000}
+                alt={
+                  <span>
+                    <USDDisplay value={vote.rshares * ratio} />
+                    <span className="ReactionsList__bullet" />
+                    <FormattedNumber
+                      style="percent" // eslint-disable-line react/style-prop-object
+                      value={vote.percent / 10000}
+                    />
+                  </span>
+                }
               />
             ))}
           </div>

--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -1,29 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedNumber } from 'react-intl';
 import FollowButton from '../widgets/FollowButton';
 import Avatar from '../components/Avatar';
-import USDDisplay from './Utils/USDDisplay';
 import './UserCard.less';
 
-const UserCard = ({ username, voteUsd, votePercent }) => (
+const UserCard = ({ username, alt }) => (
   <div className="UserCard">
     <div className="UserCard__left">
       <Link to={`/@${username}`}>
         <Avatar username={username} size={40} />
       </Link>
       <Link to={`/@${username}`}>{username}</Link>
-      <span className="UserCard__alt">
-        <span>
-          <USDDisplay value={voteUsd} />
-          <span className="ReactionsList__bullet" />
-          <FormattedNumber
-            style="percent" // eslint-disable-line react/style-prop-object
-            value={votePercent}
-          />
-        </span>
-      </span>
+      <span className="UserCard__alt">{alt}</span>
     </div>
     <FollowButton username={username} />
   </div>
@@ -31,13 +20,11 @@ const UserCard = ({ username, voteUsd, votePercent }) => (
 
 UserCard.propTypes = {
   username: PropTypes.string.isRequired,
-  voteUsd: PropTypes.number,
-  votePercent: PropTypes.number,
+  alt: PropTypes.element,
 };
 
 UserCard.defaultProps = {
-  voteUsd: 0.00,
-  votePercent: 100,
+  alt: '',
 };
 
 export default UserCard;

--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -1,18 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { FormattedNumber } from 'react-intl';
 import FollowButton from '../widgets/FollowButton';
 import Avatar from '../components/Avatar';
+import USDDisplay from './Utils/USDDisplay';
 import './UserCard.less';
 
-const UserCard = ({ username, alt }) => (
+const UserCard = ({ username, voteUsd, votePercent }) => (
   <div className="UserCard">
     <div className="UserCard__left">
       <Link to={`/@${username}`}>
         <Avatar username={username} size={40} />
       </Link>
       <Link to={`/@${username}`}>{username}</Link>
-      {alt && <span className="UserCard__alt">{alt}</span>}
+      <span className="UserCard__alt">
+        <span>
+          <USDDisplay value={voteUsd} />
+          <span className="ReactionsList__bullet" />
+          <FormattedNumber
+            style="percent" // eslint-disable-line react/style-prop-object
+            value={votePercent}
+          />
+        </span>
+      </span>
     </div>
     <FollowButton username={username} />
   </div>
@@ -20,11 +31,13 @@ const UserCard = ({ username, alt }) => (
 
 UserCard.propTypes = {
   username: PropTypes.string.isRequired,
-  alt: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  voteUsd: PropTypes.number,
+  votePercent: PropTypes.number,
 };
 
 UserCard.defaultProps = {
-  alt: '',
+  voteUsd: 0.00,
+  votePercent: 100,
 };
 
 export default UserCard;

--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -12,7 +12,7 @@ const UserCard = ({ username, alt }) => (
         <Avatar username={username} size={40} />
       </Link>
       <Link to={`/@${username}`}>{username}</Link>
-      <span className="UserCard__alt">{alt}</span>
+      {alt && <span className="UserCard__alt">{alt}</span>}
     </div>
     <FollowButton username={username} />
   </div>
@@ -20,7 +20,7 @@ const UserCard = ({ username, alt }) => (
 
 UserCard.propTypes = {
   username: PropTypes.string.isRequired,
-  alt: PropTypes.element,
+  alt: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
 };
 
 UserCard.defaultProps = {


### PR DESCRIPTION
Fixes #1080 .

Changes:

- moved `alt` prop's elements from `/components/Reactions/ReactionsList.js` to `/components/UserCard.js` because of a PropType warning where `alt` prop was sent as `object` but a `string` type was expected (screenshot below)

- removed the restriction to only show vote info for votes with the value greater than `0.1`. This way users can see all the votes information, including the downvotes information (as reported in the 1080)

Screenshot of local (`dev-server`) PropType warning that comes once you click to show the votes modal:
![votes-modal-warning-3](https://user-images.githubusercontent.com/32915194/32895074-22d9622c-cadf-11e7-89a1-f2ebaf7236fe.png)



