### PR TITLE
Append '.000Z' to cashoutInTime

### DIFF
--- a/src/client/vendor/steemitHelpers.js
+++ b/src/client/vendor/steemitHelpers.js
@@ -70,7 +70,9 @@ export const calculatePayout = post => {
   }
 
   if (cashout_active) {
-    payoutDetails.cashoutInTime = cashout_time;
+    // Append ".000Z" to make it ISO format (YYYY-MM-DDTHH:mm:ss.sssZ).
+    // It seems react-intl.formatRelative() fails to correctly compare dates if it's not in this format.
+    payoutDetails.cashoutInTime = cashout_time + ".000Z";
   }
 
   if (max_payout === 0) {


### PR DESCRIPTION
Append '.000Z' to cashoutInTime for it to be displayed correctly using intl.formatRelative()

Fixes #1062  .

Changes:
- `src/client/vendor/steemitHelpers.js` -  Append ".000Z" to make it ISO format (YYYY-MM-DDTHH:mm:ss.sssZ). It seems react-intl.formatRelative() fails to correctly compare dates if it's not in this format.
