### PR TITLE
Fix default percent_steem_dollars value

### DIFF
--- a/src/client/post/Write/editorActions.js
+++ b/src/client/post/Write/editorActions.js
@@ -102,12 +102,11 @@ const broadcastComment = (
     allow_votes: true,
     allow_curation_rewards: true,
     max_accepted_payout: '1000000.000 SBD',
-    percent_steem_dollars: 5000,
+    percent_steem_dollars: 10000,
   };
 
   if (reward === '0') {
     commentOptionsConfig.max_accepted_payout = '0.000 SBD';
-    commentOptionsConfig.percent_steem_dollars = 10000;
   } else if (reward === '100') {
     commentOptionsConfig.percent_steem_dollars = 0;
   }


### PR DESCRIPTION
The default value for `percent_steem_dollars` was set to `5000` while it should be set to `10000` to get the maximum of SBD (50%). The default value were not currently used in `stable`.
