### PR TITLE
Check if LOGIN is a refresh

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -9,7 +9,8 @@ import enUS from 'antd/lib/locale-provider/en_US';
 
 import { getAuthenticatedUser, getLocale } from './reducers';
 
-import { login, logout, getCurrentUserFollowing } from './auth/authActions';
+import { login, logout } from './auth/authActions';
+import { getFollowing } from './user/userActions';
 import { getRate, getRewardFund, getTrendingTopics } from './app/appActions';
 import Topnav from './components/Navigation/Topnav';
 import Transfer from './wallet/Transfer';
@@ -25,7 +26,7 @@ import getTranslations, { getAvailableLocale } from './translations';
   {
     login,
     logout,
-    getCurrentUserFollowing,
+    getFollowing,
     getRate,
     getRewardFund,
     getTrendingTopics,
@@ -40,7 +41,7 @@ export default class Wrapper extends React.PureComponent {
     history: PropTypes.shape().isRequired,
     login: PropTypes.func,
     logout: PropTypes.func,
-    getCurrentUserFollowing: PropTypes.func,
+    getFollowing: PropTypes.func,
     getRewardFund: PropTypes.func,
     getRebloggedList: PropTypes.func,
     getRate: PropTypes.func,
@@ -50,7 +51,7 @@ export default class Wrapper extends React.PureComponent {
   static defaultProps = {
     login: () => {},
     logout: () => {},
-    getCurrentUserFollowing: () => {},
+    getFollowing: () => {},
     getRewardFund: () => {},
     getRebloggedList: () => {},
     getRate: () => {},
@@ -62,7 +63,7 @@ export default class Wrapper extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.login().then(() => this.props.getCurrentUserFollowing());
+    this.props.login().then(() => this.props.getFollowing());
     this.props.getRewardFund();
     this.props.getRebloggedList();
     this.props.getRate();

--- a/src/client/app/appReducer.js
+++ b/src/client/app/appReducer.js
@@ -15,6 +15,7 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case authActions.LOGIN_SUCCESS:
+      if (action.meta && action.meta.refresh) return state;
       return {
         ...state,
         locale:

--- a/src/client/auth/authActions.js
+++ b/src/client/auth/authActions.js
@@ -35,6 +35,9 @@ export const login = () => (dispatch, getState, { steemConnectAPI }) => {
     payload: {
       promise,
     },
+    meta: {
+      refresh: getIsAuthenticated(getState()),
+    },
   });
 };
 

--- a/src/client/auth/authReducer.js
+++ b/src/client/auth/authReducer.js
@@ -11,6 +11,7 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case types.LOGIN_START:
+      if (action.meta && action.meta.refresh) return state;
       return {
         ...state,
         isFetching: true,
@@ -19,6 +20,7 @@ export default (state = initialState, action) => {
         user: {},
       };
     case types.LOGIN_SUCCESS:
+      if (action.meta && action.meta.refresh) return state;
       return {
         ...state,
         isFetching: false,

--- a/src/client/bookmarks/bookmarksReducer.js
+++ b/src/client/bookmarks/bookmarksReducer.js
@@ -9,6 +9,7 @@ const initialState = {
 const bookmarks = (state = initialState, action) => {
   switch (action.type) {
     case authActions.LOGIN_SUCCESS:
+      if (action.meta && action.meta.refresh) return state;
       return {
         ...state,
         list: action.payload.user_metadata.bookmarks || initialState.list,

--- a/src/client/post/Write/editorReducer.js
+++ b/src/client/post/Write/editorReducer.js
@@ -30,6 +30,7 @@ const editor = (state = defaultState, action) => {
         editedPosts: state.editedPosts.filter(post => post !== action.payload),
       };
     case authActions.LOGIN_SUCCESS:
+      if (action.meta && action.meta.refresh) return state;
       return {
         ...state,
         draftPosts: action.payload.user_metadata.drafts || defaultState.draftPosts,

--- a/src/client/settings/settingsReducer.js
+++ b/src/client/settings/settingsReducer.js
@@ -13,16 +13,17 @@ const settings = (state = initialState, action) => {
   switch (action.type) {
     case authTypes.LOGIN_SUCCESS:
     case authTypes.RELOAD_SUCCESS:
+      if (action.meta && action.meta.refresh) return state;
       if (action.payload.user_metadata && action.payload.user_metadata.settings) {
         return {
           ...state,
           locale: action.payload.user_metadata.settings.locale || initialState.locale,
-          votingPower: action.payload.user_metadata.settings.votingPower ||
-            initialState.votingPower,
-          votePercent: action.payload.user_metadata.settings.votePercent ||
-            initialState.votePercent,
-          showNSFWPosts: action.payload.user_metadata.settings.showNSFWPosts ||
-            initialState.showNSFWPosts,
+          votingPower:
+            action.payload.user_metadata.settings.votingPower || initialState.votingPower,
+          votePercent:
+            action.payload.user_metadata.settings.votePercent || initialState.votePercent,
+          showNSFWPosts:
+            action.payload.user_metadata.settings.showNSFWPosts || initialState.showNSFWPosts,
         };
       }
       return state;


### PR DESCRIPTION
This fixes issue with SSR preventing user to sign in.

Changes:
- Add `meta.refresh` to action to inform reducers that this is refresh and doesn't contain reducer.
- If `meta.refresh` is set to true don't update state.
