### PR TITLE
Add space to post body for empty posts to fix Quick Post Creation

### DIFF
--- a/src/client/components/QuickPostEditor/QuickPostEditor.js
+++ b/src/client/components/QuickPostEditor/QuickPostEditor.js
@@ -50,7 +50,6 @@ class QuickPostEditor extends React.Component {
     imageUploading: false,
     dropzoneActive: false,
     currentInputValue: '',
-    currentPostBody: '',
     currentImages: [],
     focusedInput: false,
     inputMinRows: 1,
@@ -82,7 +81,7 @@ class QuickPostEditor extends React.Component {
         const imageText = `![${image.name}](${image.src})\n`;
         return `${str}${imageText}`;
       },
-      '',
+      ' ',
     );
     const postTitle = this.state.currentInputValue;
     const data = {


### PR DESCRIPTION
Fixes #1153 .

Changes:
- add space to post body for posts with no pics since we are using title to create the post for quick post creation
