### PR TITLE
use targetUsername instead of username in userActions

### DIFF
--- a/src/client/user/userActions.js
+++ b/src/client/user/userActions.js
@@ -132,7 +132,7 @@ export const getFollowing = username => (dispatch, getState) => {
     type: GET_FOLLOWING,
     meta: targetUsername,
     payload: {
-      promise: getAllFollowing(username),
+      promise: getAllFollowing(targetUsername),
     },
   });
 };


### PR DESCRIPTION
Fixes #1145 
Fixes #1148 

Changes:
- use targetUsername instead of username in userActions

