### PR TITLE
Log initial page view

### DIFF
--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -9,6 +9,7 @@ import routes from '../common/routes';
 const history = typeof window === 'undefined' ? createMemoryHistory() : createBrowserHistory();
 
 if (typeof window !== 'undefined' && window.analytics) {
+  window.analytics.page({ url: history.location.pathname });
   history.listen((location) => {
     window.analytics.page({ url: location.pathname });
   });


### PR DESCRIPTION
Should fix recent drop in statistics. Before it didn't send `pageview` event on initial load.
Changes:
- Send `pageview` on initial load
