### PR TITLE
Fix all feed

### DIFF
--- a/src/client/feed/feedActions.js
+++ b/src/client/feed/feedActions.js
@@ -38,14 +38,14 @@ export const getMoreUserFeedContentSuccess = createAction(GET_MORE_USER_FEED_CON
 export const feedHasNoMore = createAction(FEED_HAS_NO_MORE);
 
 export const getFeedContent = (
-  { sortBy = 'trending', category = 'all', limit },
+  { sortBy = 'trending', category, limit },
   resolve = () => {},
   reject = () => {},
 ) => (dispatch, getState, { steemAPI }) => {
   dispatch(
     getFeedContentWithoutAPI({
       sortBy,
-      category,
+      category: category || 'all',
     }),
   );
 
@@ -61,7 +61,7 @@ export const getFeedContent = (
       dispatch(
         getFeedContentSuccess({
           sortBy,
-          category,
+          category: category || 'all',
           postsData,
           limit,
         }),


### PR DESCRIPTION
This fixes issue with wrong feed appearing when no tag is specified.
We have to send request with no `tag` at all, to get content from everywhere.

Changes:
- Send empty tag if none is specified.
