### PR TITLE
Create SidebarContentBlock.less styles and apply it to all sidebar

### DIFF
--- a/src/client/activity/UserActivitySearch.js
+++ b/src/client/activity/UserActivitySearch.js
@@ -8,6 +8,7 @@ import { getUser, getAuthenticatedUser } from '../reducers';
 import * as accountHistoryConstants from '../../common/constants/accountHistory';
 import { updateAccountHistoryFilter } from '../wallet/walletActions';
 import './UserActivitySearch.less';
+import '../components/Sidebar/SidebarContentBlock.less';
 
 const filterValues = {
   [accountHistoryConstants.UPVOTED]: {
@@ -215,12 +216,12 @@ class UserActivitySearch extends React.Component {
     const { showGeneral, showFinance, showRewards } = this.state;
 
     return (
-      <div className="UserActivitySearch">
-        <h4 className="UserActivitySearch__title">
-          <i className="iconfont icon-trysearchlist UserActivitySearch__title__icon" />
+      <div className="UserActivitySearch SidebarContentBlock">
+        <h4 className="SidebarContentBlock__title">
+          <i className="iconfont icon-trysearchlist SidebarContentBlock__icon" />
           <FormattedMessage id="filter_activities" defaultMessage="Filter Activities" />
         </h4>
-        <div className="UserActivitySearch__filters__divider" />
+        <div className="SidebarContentBlock__divider" />
         <div className="UserActivitySearch__filters">
           <div className="UserActivitySearch__filters__container">
             <div

--- a/src/client/activity/UserActivitySearch.less
+++ b/src/client/activity/UserActivitySearch.less
@@ -1,27 +1,10 @@
 @import (reference) "../styles/custom.less";
 
 .UserActivitySearch {
-  background-color: @white;
-  border-radius: 4px;
-  border: 1px solid @white-gainsboro;
   color: @purple;
-  margin-bottom: 1em;
-  padding: 8px 16px 16px;
   text-align: left;
   width: 270px;
   overflow: auto;
-
-  &__title {
-    color: @blue-botticelli;
-    font-size: 18px;
-    font-weight: 500;
-
-    &__icon {
-      color: @purple;
-      margin-right: 5px;
-      vertical-align: -2px;
-    }
-  }
 
   &__filters {
     &__title {

--- a/src/client/components/Icon/Loading.less
+++ b/src/client/components/Icon/Loading.less
@@ -1,6 +1,9 @@
+@import (reference) "../../styles/custom.less";
+
 .Loading {
   & > &__icon {
     font-size: 36px !important;
+    color: @purple;
   }
 
   &--center {

--- a/src/client/components/Sidebar/CryptoChart.js
+++ b/src/client/components/Sidebar/CryptoChart.js
@@ -119,7 +119,7 @@ class CryptoChart extends React.Component {
         {loading
           ? <Loading />
           : <Trend data={currentCryptoPriceHistory} stroke={'#4757b2'} strokeWidth={5} />}
-        {renderDivider && <div className="CryptoTrendingCharts__divider" />}
+        {renderDivider && <div className="SidebarContentBlock__divider" />}
       </div>
     );
   }

--- a/src/client/components/Sidebar/CryptoTrendingCharts.js
+++ b/src/client/components/Sidebar/CryptoTrendingCharts.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import CryptoChart from './CryptoChart';
 import './CryptoTrendingCharts.less';
+import './SidebarContentBlock.less';
 
 class CryptoTrendingCharts extends React.Component {
   static propTypes = {
@@ -59,9 +60,9 @@ class CryptoTrendingCharts extends React.Component {
 
   render() {
     return (
-      <div className="CryptoTrendingCharts">
-        <h4 className="CryptoTrendingCharts__title">
-          <i className="iconfont icon-chart CryptoTrendingCharts__icon" />
+      <div className="SidebarContentBlock">
+        <h4 className="SidebarContentBlock__title">
+          <i className="iconfont icon-chart SidebarContentBlock__icon" />
           <FormattedMessage id="market" defaultMessage="Market" />
           <i
             role="presentation"
@@ -69,7 +70,7 @@ class CryptoTrendingCharts extends React.Component {
             className="iconfont icon-refresh CryptoTrendingCharts__icon-refresh"
           />
         </h4>
-        <div className="CryptoTrendingCharts__divider" />
+        <div className="SidebarContentBlock__divider" />
         {this.renderCryptoCharts()}
       </div>
     );

--- a/src/client/components/Sidebar/CryptoTrendingCharts.less
+++ b/src/client/components/Sidebar/CryptoTrendingCharts.less
@@ -1,31 +1,6 @@
 @import (reference) "../../styles/custom.less";
 
 .CryptoTrendingCharts {
-  background: @white;
-  border-radius: 4px;
-  border: 1px solid @white-gainsboro;
-  padding: 8px 16px 16px 16px;
-  margin-bottom: 10px;
-
-  &__title {
-    color: @blue-botticelli;
-    font-size: 18px;
-    font-weight: 500;
-  }
-
-  &__divider {
-    width: 100%;
-    height: 1px;
-    margin: 12px 0;
-    background-color: @white-gainsboro;
-  }
-
-  &__icon {
-    color: @purple;
-    margin-right: 5px;
-    vertical-align: -2px;
-  }
-
   &__icon-refresh {
     font-size: 22px !important;
     float: right;

--- a/src/client/components/Sidebar/InterestingPeople.js
+++ b/src/client/components/Sidebar/InterestingPeople.js
@@ -4,34 +4,27 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import User from './User';
 import './InterestingPeople.less';
+import './SidebarContentBlock.less';
 
 const InterestingPeople = ({ users, onRefresh }) => (
-  <div className="InterestingPeople">
-    <div className="InterestingPeople__container">
-      <h4 className="InterestingPeople__title">
-        <i className="iconfont icon-group InterestingPeople__icon" />
-        {' '}
-        <FormattedMessage id="interesting_people" defaultMessage="Interesting People" />
-        <i
-          role="presentation"
-          onClick={onRefresh}
-          className="iconfont icon-refresh InterestingPeople__icon-refresh"
-        />
-      </h4>
-      <div className="InterestingPeople__divider" />
-      {users &&
-        users.map(user => (
-          <User
-            key={user.name}
-            user={user}
-          />
-        ))}
-      <h4 className="InterestingPeople__more">
-        <Link to={'/discover'}>
-          <FormattedMessage id="discover_more_people" defaultMessage="Discover More People" />
-        </Link>
-      </h4>
-    </div>
+  <div className="InterestingPeople SidebarContentBlock">
+    <h4 className="SidebarContentBlock__title">
+      <i className="iconfont icon-group SidebarContentBlock__icon" />
+      {' '}
+      <FormattedMessage id="interesting_people" defaultMessage="Interesting People" />
+      <i
+        role="presentation"
+        onClick={onRefresh}
+        className="iconfont icon-refresh InterestingPeople__icon-refresh"
+      />
+    </h4>
+    <div className="SidebarContentBlock__divider" />
+    {users && users.map(user => <User key={user.name} user={user} />)}
+    <h4 className="InterestingPeople__more">
+      <Link to={'/discover'}>
+        <FormattedMessage id="discover_more_people" defaultMessage="Discover More People" />
+      </Link>
+    </h4>
   </div>
 );
 

--- a/src/client/components/Sidebar/InterestingPeople.less
+++ b/src/client/components/Sidebar/InterestingPeople.less
@@ -1,20 +1,5 @@
 @import (reference) "../../styles/custom.less";
 
-.InterestingPeople {
-  background: @white;
-  border: 1px solid #e9e7e7;
-  border-radius: @border-radius-base;
-}
-
-.InterestingPeople__container {
-  padding: 8px 16px 16px 16px;
-}
-
-.InterestingPeople__icon {
-  color: @purple;
-  vertical-align: -2px;
-}
-
 .InterestingPeople__icon-refresh {
   font-size: 22px !important;
   float: right;
@@ -26,13 +11,6 @@
   color: #99aab5;
   font-size: 18px;
   font-weight: 500;
-}
-
-.InterestingPeople__divider {
-  width: 100%;
-  height: 1px;
-  margin: 12px 0;
-  background-color: #e9e7e7;
 }
 
 .InterestingPeople__more > a {

--- a/src/client/components/Sidebar/InterestingPeopleWithAPI.js
+++ b/src/client/components/Sidebar/InterestingPeopleWithAPI.js
@@ -7,9 +7,9 @@ import User from './User';
 import Loading from '../../components/Icon/Loading';
 import steemAPI from '../../steemAPI';
 import './InterestingPeople.less';
+import './SidebarContentBlock.less';
 
-@withRouter
-class InterestingPeopleWithAPI extends Component {
+@withRouter class InterestingPeopleWithAPI extends Component {
   static propTypes = {
     authenticatedUser: PropTypes.shape({
       name: PropTypes.string,
@@ -92,20 +92,18 @@ class InterestingPeopleWithAPI extends Component {
     }
 
     return (
-      <div className="InterestingPeople">
-        <div className="InterestingPeople__container">
-          <h4 className="InterestingPeople__title">
-            <i className="iconfont icon-group InterestingPeople__icon" />{' '}
-            <FormattedMessage id="top_reblogged_users" defaultMessage="Top Reblogged Users" />
-          </h4>
-          <div className="InterestingPeople__divider" />
-          {users && users.map(user => <User key={user.name} user={user} />)}
-          <h4 className="InterestingPeople__more">
-            <Link to={'/discover'}>
-              <FormattedMessage id="discover_more_people" defaultMessage="Discover More People" />
-            </Link>
-          </h4>
-        </div>
+      <div className="SidebarContentBlock">
+        <h4 className="SidebarContentBlock__title">
+          <i className="iconfont icon-group SidebarContentBlock__icon" />{' '}
+          <FormattedMessage id="top_reblogged_users" defaultMessage="Top Reblogged Users" />
+        </h4>
+        <div className="SidebarContentBlock__divider" />
+        {users && users.map(user => <User key={user.name} user={user} />)}
+        <h4 className="InterestingPeople__more">
+          <Link to={'/discover'}>
+            <FormattedMessage id="discover_more_people" defaultMessage="Discover More People" />
+          </Link>
+        </h4>
       </div>
     );
   }

--- a/src/client/components/Sidebar/InterestingPeopleWithAPI.js
+++ b/src/client/components/Sidebar/InterestingPeopleWithAPI.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
@@ -9,7 +9,7 @@ import steemAPI from '../../steemAPI';
 import './InterestingPeople.less';
 import './SidebarContentBlock.less';
 
-@withRouter class InterestingPeopleWithAPI extends Component {
+@withRouter class InterestingPeopleWithAPI extends React.Component {
   static propTypes = {
     authenticatedUser: PropTypes.shape({
       name: PropTypes.string,

--- a/src/client/components/Sidebar/PostRecommendation.js
+++ b/src/client/components/Sidebar/PostRecommendation.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
-import './PostRecommendation.less';
 import Loading from '../../components/Icon/Loading';
 import steemAPI from '../../steemAPI';
+import './PostRecommendation.less';
+import './SidebarContentBlock.less';
 
 @withRouter
 class PostRecommendation extends Component {
@@ -141,11 +142,12 @@ class PostRecommendation extends Component {
     }
 
     return (
-      <div className="PostRecommendation">
-        <h4 className="PostRecommendation__title SidebarBlock__content-title">
-          <i className="iconfont icon-headlines PostRecommendation__icon" />{' '}
+      <div className="SidebarContentBlock">
+        <h4 className="SidebarContentBlock__title">
+          <i className="iconfont icon-headlines SidebarContentBlock__icon" />{' '}
           <FormattedMessage id="recommended_posts" defaultMessage="Recommended Posts" />
         </h4>
+        <div className="SidebarContentBlock__divider" />
         {this.renderPosts()}
       </div>
     );

--- a/src/client/components/Sidebar/PostRecommendation.less
+++ b/src/client/components/Sidebar/PostRecommendation.less
@@ -1,21 +1,6 @@
 @import (reference) "../../styles/custom.less";
 
 .PostRecommendation {
-  background: @white;
-  border: 1px solid @white-gainsboro;
-  border-radius: @border-radius-base;
-  padding: 8px 16px 16px 16px;
-
-  &__icon {
-    color: @purple;
-    vertical-align: -2px;
-  }
-
-  &__title {
-    border-bottom: 1px solid @white-gainsboro;
-    padding-bottom: 8px;
-  }
-
   &__link {
     border-bottom: 1px solid @white-gainsboro;
     font-size: 15px;

--- a/src/client/components/Sidebar/SidebarContentBlock.less
+++ b/src/client/components/Sidebar/SidebarContentBlock.less
@@ -1,0 +1,28 @@
+@import (reference) "../../styles/custom.less";
+
+.SidebarContentBlock {
+  background: @white;
+  border-radius: 4px;
+  border: 1px solid @white-gainsboro;
+  padding: 8px 16px 16px 16px;
+  margin-bottom: 10px;
+
+  &__title {
+    color: @blue-botticelli;
+    font-size: 18px;
+    font-weight: 500;
+  }
+
+  &__icon {
+    color: @purple;
+    margin-right: 5px;
+    vertical-align: -2px;
+  }
+
+  &__divider {
+    width: 100%;
+    height: 1px;
+    margin: 12px 0;
+    background-color: @white-gainsboro;
+  }
+}

--- a/src/client/components/Sidebar/__tests__/__snapshots__/InterestingPeople.js.snap
+++ b/src/client/components/Sidebar/__tests__/__snapshots__/InterestingPeople.js.snap
@@ -35,14 +35,12 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "host",
     "props": Object {
-      "children": <div
-        className="InterestingPeople__container"
-      >
+      "children": Array [
         <h4
-          className="InterestingPeople__title"
+          className="SidebarContentBlock__title"
         >
           <i
-            className="iconfont icon-group InterestingPeople__icon"
+            className="iconfont icon-group SidebarContentBlock__icon"
           />
            
           <FormattedMessage
@@ -55,38 +53,40 @@ ShallowWrapper {
             onClick={[Function]}
             role="presentation"
           />
-        </h4>
+        </h4>,
         <div
-          className="InterestingPeople__divider"
-        />
-        <User
-          user={
-            Object {
-              "name": "sekhmet",
+          className="SidebarContentBlock__divider"
+        />,
+        Array [
+          <User
+            user={
+              Object {
+                "name": "sekhmet",
+              }
             }
-          }
-        />
-        <User
-          user={
-            Object {
-              "name": "fabien",
+          />,
+          <User
+            user={
+              Object {
+                "name": "fabien",
+              }
             }
-          }
-        />
-        <User
-          user={
-            Object {
-              "name": "ekitcho",
+          />,
+          <User
+            user={
+              Object {
+                "name": "ekitcho",
+              }
             }
-          }
-        />
-        <User
-          user={
-            Object {
-              "name": "jm90mm",
+          />,
+          <User
+            user={
+              Object {
+                "name": "jm90mm",
+              }
             }
-          }
-        />
+          />,
+        ],
         <h4
           className="InterestingPeople__more"
         >
@@ -100,22 +100,205 @@ ShallowWrapper {
               values={Object {}}
             />
           </Link>
-        </h4>
-      </div>,
-      "className": "InterestingPeople",
+        </h4>,
+      ],
+      "className": "InterestingPeople SidebarContentBlock",
     },
     "ref": null,
-    "rendered": Object {
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <i
+              className="iconfont icon-group SidebarContentBlock__icon"
+            />,
+            " ",
+            <FormattedMessage
+              defaultMessage="Interesting People"
+              id="interesting_people"
+              values={Object {}}
+            />,
+            <i
+              className="iconfont icon-refresh InterestingPeople__icon-refresh"
+              onClick={[Function]}
+              role="presentation"
+            />,
+          ],
+          "className": "SidebarContentBlock__title",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "className": "iconfont icon-group SidebarContentBlock__icon",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": "i",
+          },
+          " ",
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultMessage": "Interesting People",
+              "id": "interesting_people",
+              "values": Object {},
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "className": "iconfont icon-refresh InterestingPeople__icon-refresh",
+              "onClick": [Function],
+              "role": "presentation",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": "i",
+          },
+        ],
+        "type": "h4",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "className": "SidebarContentBlock__divider",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": "sekhmet",
+        "nodeType": "function",
+        "props": Object {
+          "user": Object {
+            "name": "sekhmet",
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "fabien",
+        "nodeType": "function",
+        "props": Object {
+          "user": Object {
+            "name": "fabien",
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "ekitcho",
+        "nodeType": "function",
+        "props": Object {
+          "user": Object {
+            "name": "ekitcho",
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "jm90mm",
+        "nodeType": "function",
+        "props": Object {
+          "user": Object {
+            "name": "jm90mm",
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <Link
+            replace={false}
+            to="/discover"
+          >
+            <FormattedMessage
+              defaultMessage="Discover More People"
+              id="discover_more_people"
+              values={Object {}}
+            />
+          </Link>,
+          "className": "InterestingPeople__more",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <FormattedMessage
+              defaultMessage="Discover More People"
+              id="discover_more_people"
+              values={Object {}}
+            />,
+            "replace": false,
+            "to": "/discover",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "defaultMessage": "Discover More People",
+              "id": "discover_more_people",
+              "values": Object {},
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        "type": "h4",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
       "instance": null,
       "key": undefined,
       "nodeType": "host",
       "props": Object {
         "children": Array [
           <h4
-            className="InterestingPeople__title"
+            className="SidebarContentBlock__title"
           >
             <i
-              className="iconfont icon-group InterestingPeople__icon"
+              className="iconfont icon-group SidebarContentBlock__icon"
             />
              
             <FormattedMessage
@@ -130,7 +313,7 @@ ShallowWrapper {
             />
           </h4>,
           <div
-            className="InterestingPeople__divider"
+            className="SidebarContentBlock__divider"
           />,
           Array [
             <User
@@ -177,7 +360,7 @@ ShallowWrapper {
             </Link>
           </h4>,
         ],
-        "className": "InterestingPeople__container",
+        "className": "InterestingPeople SidebarContentBlock",
       },
       "ref": null,
       "rendered": Array [
@@ -188,7 +371,7 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               <i
-                className="iconfont icon-group InterestingPeople__icon"
+                className="iconfont icon-group SidebarContentBlock__icon"
               />,
               " ",
               <FormattedMessage
@@ -202,7 +385,7 @@ ShallowWrapper {
                 role="presentation"
               />,
             ],
-            "className": "InterestingPeople__title",
+            "className": "SidebarContentBlock__title",
           },
           "ref": null,
           "rendered": Array [
@@ -211,7 +394,7 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "className": "iconfont icon-group InterestingPeople__icon",
+                "className": "iconfont icon-group SidebarContentBlock__icon",
               },
               "ref": null,
               "rendered": null,
@@ -252,7 +435,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "className": "InterestingPeople__divider",
+            "className": "SidebarContentBlock__divider",
           },
           "ref": null,
           "rendered": null,
@@ -360,343 +543,6 @@ ShallowWrapper {
           "type": "h4",
         },
       ],
-      "type": "div",
-    },
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <div
-          className="InterestingPeople__container"
-        >
-          <h4
-            className="InterestingPeople__title"
-          >
-            <i
-              className="iconfont icon-group InterestingPeople__icon"
-            />
-             
-            <FormattedMessage
-              defaultMessage="Interesting People"
-              id="interesting_people"
-              values={Object {}}
-            />
-            <i
-              className="iconfont icon-refresh InterestingPeople__icon-refresh"
-              onClick={[Function]}
-              role="presentation"
-            />
-          </h4>
-          <div
-            className="InterestingPeople__divider"
-          />
-          <User
-            user={
-              Object {
-                "name": "sekhmet",
-              }
-            }
-          />
-          <User
-            user={
-              Object {
-                "name": "fabien",
-              }
-            }
-          />
-          <User
-            user={
-              Object {
-                "name": "ekitcho",
-              }
-            }
-          />
-          <User
-            user={
-              Object {
-                "name": "jm90mm",
-              }
-            }
-          />
-          <h4
-            className="InterestingPeople__more"
-          >
-            <Link
-              replace={false}
-              to="/discover"
-            >
-              <FormattedMessage
-                defaultMessage="Discover More People"
-                id="discover_more_people"
-                values={Object {}}
-              />
-            </Link>
-          </h4>
-        </div>,
-        "className": "InterestingPeople",
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": Array [
-            <h4
-              className="InterestingPeople__title"
-            >
-              <i
-                className="iconfont icon-group InterestingPeople__icon"
-              />
-               
-              <FormattedMessage
-                defaultMessage="Interesting People"
-                id="interesting_people"
-                values={Object {}}
-              />
-              <i
-                className="iconfont icon-refresh InterestingPeople__icon-refresh"
-                onClick={[Function]}
-                role="presentation"
-              />
-            </h4>,
-            <div
-              className="InterestingPeople__divider"
-            />,
-            Array [
-              <User
-                user={
-                  Object {
-                    "name": "sekhmet",
-                  }
-                }
-              />,
-              <User
-                user={
-                  Object {
-                    "name": "fabien",
-                  }
-                }
-              />,
-              <User
-                user={
-                  Object {
-                    "name": "ekitcho",
-                  }
-                }
-              />,
-              <User
-                user={
-                  Object {
-                    "name": "jm90mm",
-                  }
-                }
-              />,
-            ],
-            <h4
-              className="InterestingPeople__more"
-            >
-              <Link
-                replace={false}
-                to="/discover"
-              >
-                <FormattedMessage
-                  defaultMessage="Discover More People"
-                  id="discover_more_people"
-                  values={Object {}}
-                />
-              </Link>
-            </h4>,
-          ],
-          "className": "InterestingPeople__container",
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <i
-                  className="iconfont icon-group InterestingPeople__icon"
-                />,
-                " ",
-                <FormattedMessage
-                  defaultMessage="Interesting People"
-                  id="interesting_people"
-                  values={Object {}}
-                />,
-                <i
-                  className="iconfont icon-refresh InterestingPeople__icon-refresh"
-                  onClick={[Function]}
-                  role="presentation"
-                />,
-              ],
-              "className": "InterestingPeople__title",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "className": "iconfont icon-group InterestingPeople__icon",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": "i",
-              },
-              " ",
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "defaultMessage": "Interesting People",
-                  "id": "interesting_people",
-                  "values": Object {},
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "className": "iconfont icon-refresh InterestingPeople__icon-refresh",
-                  "onClick": [Function],
-                  "role": "presentation",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": "i",
-              },
-            ],
-            "type": "h4",
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "className": "InterestingPeople__divider",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": "div",
-          },
-          Object {
-            "instance": null,
-            "key": "sekhmet",
-            "nodeType": "function",
-            "props": Object {
-              "user": Object {
-                "name": "sekhmet",
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": "fabien",
-            "nodeType": "function",
-            "props": Object {
-              "user": Object {
-                "name": "fabien",
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": "ekitcho",
-            "nodeType": "function",
-            "props": Object {
-              "user": Object {
-                "name": "ekitcho",
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": "jm90mm",
-            "nodeType": "function",
-            "props": Object {
-              "user": Object {
-                "name": "jm90mm",
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": <Link
-                replace={false}
-                to="/discover"
-              >
-                <FormattedMessage
-                  defaultMessage="Discover More People"
-                  id="discover_more_people"
-                  values={Object {}}
-                />
-              </Link>,
-              "className": "InterestingPeople__more",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "children": <FormattedMessage
-                  defaultMessage="Discover More People"
-                  id="discover_more_people"
-                  values={Object {}}
-                />,
-                "replace": false,
-                "to": "/discover",
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "defaultMessage": "Discover More People",
-                  "id": "discover_more_people",
-                  "values": Object {},
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            "type": "h4",
-          },
-        ],
-        "type": "div",
-      },
       "type": "div",
     },
   ],

--- a/src/client/helpers/cryptosHelper.js
+++ b/src/client/helpers/cryptosHelper.js
@@ -10,7 +10,11 @@ export function getCryptoDetails(cryptoQuery) {
 
   const cryptoDetails = _.find(CRYPTO_MAP, (crypto) => {
     const formattedCryptoName = _.toLower(crypto.name).replace(/\s/g, ''); // lowercase & remove spaces
-    return _.includes(formattedCryptoName, cryptoQuery);
+    const formattedCryptoSymbol = _.toLower(crypto.symbol);
+    const matchesCryptoId = crypto.id === cryptoQuery;
+    const matchesCryptoName = formattedCryptoName === cryptoQuery;
+    const matchesCryptoSymbol = formattedCryptoSymbol === cryptoQuery;
+    return matchesCryptoId || matchesCryptoName || matchesCryptoSymbol;
   });
 
   return cryptoDetails || {};


### PR DESCRIPTION
Fixes #1211.

Changes:
- Update all sidebar blocks with content (crypto charts, interesting people, post recommendation) to use same styles for class name for background, title, icon and divider
- Also update cryptosHelper - getCryptoDetails to find exact matches for posts tagged with crypto
- Also update loader styles to always be purple
