### PR TITLE
Use Padding instead of Margin for Loader Container in UserWalletTranactions

### DIFF
--- a/src/client/wallet/UserWalletTransactions.js
+++ b/src/client/wallet/UserWalletTransactions.js
@@ -59,7 +59,7 @@ class UserWalletTransactions extends React.Component {
           hasMore={userHasMoreActions}
           elementIsScrollable={false}
           threshold={500}
-          loader={<div style={{ margin: '20px' }}><Loading /></div>}
+          loader={<div style={{ padding: '20px' }}><Loading /></div>}
           loadingMore={loadingMoreUsersAccountHistory}
         >
           <div />

--- a/src/client/wallet/UserWalletTransactions.js
+++ b/src/client/wallet/UserWalletTransactions.js
@@ -59,7 +59,7 @@ class UserWalletTransactions extends React.Component {
           hasMore={userHasMoreActions}
           elementIsScrollable={false}
           threshold={500}
-          loader={<div style={{ padding: '20px' }}><Loading /></div>}
+          loader={<div className="UserWalletTransactions__loader"><Loading /></div>}
           loadingMore={loadingMoreUsersAccountHistory}
         >
           <div />

--- a/src/client/wallet/UserWalletTransactions.less
+++ b/src/client/wallet/UserWalletTransactions.less
@@ -12,6 +12,20 @@
     display: none;
   }
 
+  &__loader {
+    border-bottom-left-radius: @border-radius-base;
+    border-bottom-right-radius: @border-radius-base;
+    border-bottom: 1px solid @white-gainsboro;
+    border-left: 1px solid @white-gainsboro;
+    border-right: 1px solid @white-gainsboro;
+    padding: 20px;
+
+    &:nth-of-type(2) {
+      border-top: 1px solid @white-gainsboro;
+      border-radius: @border-radius-base;
+    }
+  }
+
   &__transaction {
     color: @grey-nightRider;
     display: flex;

--- a/src/client/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
+++ b/src/client/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
@@ -60,7 +60,7 @@ ShallowWrapper {
           <div
             style={
               Object {
-                "margin": "20px",
+                "padding": "20px",
               }
             }
           >
@@ -176,7 +176,7 @@ ShallowWrapper {
         "loader": <div
           style={
             Object {
-              "margin": "20px",
+              "padding": "20px",
             }
           }
         >
@@ -278,7 +278,7 @@ ShallowWrapper {
             <div
               style={
                 Object {
-                  "margin": "20px",
+                  "padding": "20px",
                 }
               }
             >
@@ -394,7 +394,7 @@ ShallowWrapper {
           "loader": <div
             style={
               Object {
-                "margin": "20px",
+                "padding": "20px",
               }
             }
           >

--- a/src/client/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
+++ b/src/client/wallet/__tests__/__snapshots__/UserWalletTransactions.test.js.snap
@@ -58,11 +58,7 @@ ShallowWrapper {
         loadMore={[Function]}
         loader={
           <div
-            style={
-              Object {
-                "padding": "20px",
-              }
-            }
+            className="UserWalletTransactions__loader"
           >
             <Loading
               center={true}
@@ -174,11 +170,7 @@ ShallowWrapper {
         "items": Array [],
         "loadMore": [Function],
         "loader": <div
-          style={
-            Object {
-              "padding": "20px",
-            }
-          }
+          className="UserWalletTransactions__loader"
         >
           <Loading
             center={true}
@@ -276,11 +268,7 @@ ShallowWrapper {
           loadMore={[Function]}
           loader={
             <div
-              style={
-                Object {
-                  "padding": "20px",
-                }
-              }
+              className="UserWalletTransactions__loader"
             >
               <Loading
                 center={true}
@@ -392,11 +380,7 @@ ShallowWrapper {
           "items": Array [],
           "loadMore": [Function],
           "loader": <div
-            style={
-              Object {
-                "padding": "20px",
-              }
-            }
+            className="UserWalletTransactions__loader"
           >
             <Loading
               center={true}


### PR DESCRIPTION
Use Padding instead of Margin for Loader Container in UserWalletTranactions
Fixes:
Activity Loader with no padding in UserWallet see `/@busy.witness/transfers`

Changes:
- use padding instead of margin
