### PR TITLE
Don't update post state after liking. Fixes #1222

### DIFF
--- a/src/client/post/postsReducer.js
+++ b/src/client/post/postsReducer.js
@@ -81,6 +81,7 @@ const posts = (state = initialState, action) => {
       };
     }
     case postsActions.GET_CONTENT.START:
+      if (action.meta.afterLike) return state;
       return {
         ...state,
         postsStates: {


### PR DESCRIPTION
Changes:
- Don't update post state after liking.
