### PR TITLE
Include rate in vote value calculation

### DIFF
--- a/src/client/app/appActions.js
+++ b/src/client/app/appActions.js
@@ -13,8 +13,7 @@ export const GET_REWARD_FUND_START = '@app/GET_REWARD_FUND_START';
 export const GET_REWARD_FUND_SUCCESS = '@app/GET_REWARD_FUND_SUCCESS';
 export const GET_REWARD_FUND_ERROR = '@app/GET_REWARD_FUND_ERROR';
 
-export const RATE_REQUEST = '@app/RATE_REQUEST';
-export const RATE_SUCCESS = '@app/RATE_SUCCESS';
+export const RATE_REQUEST = createAsyncActionType('@app/RATE_REQUEST');
 
 export const CLOSE_BANNER = '@app/CLOSE_BANNER';
 export const closeBanner = createAction(CLOSE_BANNER);
@@ -26,14 +25,12 @@ export const GET_CRYPTO_PRICE_HISTORY = createAsyncActionType('@app/GET_CRYPTOS_
 export const REFRESH_CRYPTO_PRICE_HISTORY = '@app/REFRESH_CRYPTO_PRICE_HISTORY';
 export const refreshCryptoPriceHistory = createAction(REFRESH_CRYPTO_PRICE_HISTORY);
 
-export const getRate = () => (dispatch) => {
-  dispatch({ type: RATE_REQUEST });
-  fetch('https://api.coinmarketcap.com/v1/ticker/steem/').then(res => res.json()).then((json) => {
-    const rate = parseFloat(json[0].price_usd);
-    dispatch({
-      type: RATE_SUCCESS,
-      rate,
-    });
+export const getRate = () => (dispatch, getState, { steemAPI }) => {
+  dispatch({
+    type: RATE_REQUEST.ACTION,
+    payload: {
+      promise: steemAPI.sendAsync('get_current_median_history_price', []).then(resp => parseFloat(resp.base)),
+    },
   });
 };
 

--- a/src/client/app/appReducer.js
+++ b/src/client/app/appReducer.js
@@ -28,10 +28,10 @@ export default (state = initialState, action) => {
           (action.payload.user_metadata && action.payload.user_metadata.locale) ||
           initialState.locale,
       };
-    case appTypes.RATE_SUCCESS:
+    case appTypes.RATE_REQUEST.SUCCESS:
       return {
         ...state,
-        rate: action.rate,
+        rate: action.payload,
       };
     case postActions.GET_CONTENT.START:
       return {

--- a/src/client/components/StoryFooter/StoryFooter.js
+++ b/src/client/components/StoryFooter/StoryFooter.js
@@ -1,19 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import find from 'lodash/find';
 import Slider from '../Slider/Slider';
 import Payout from './Payout';
 import Buttons from './Buttons';
 import Confirmation from './Confirmation';
 import { getHasDefaultSlider, getVoteValue } from '../../helpers/user';
+import { getRate } from '../../reducers';
 import './StoryFooter.less';
 
+@connect(state => ({
+  rate: getRate(state),
+}))
 class StoryFooter extends React.Component {
   static propTypes = {
     user: PropTypes.shape().isRequired,
     post: PropTypes.shape().isRequired,
     postState: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
+    rate: PropTypes.number.isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     ownPost: PropTypes.bool,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
@@ -79,11 +85,12 @@ class StoryFooter extends React.Component {
   handleSliderCancel = () => this.setState({ sliderVisible: false });
 
   handleSliderChange = (value) => {
-    const { user, rewardFund } = this.props;
+    const { user, rewardFund, rate } = this.props;
     const voteWorth = getVoteValue(
       user,
       rewardFund.recent_claims,
       rewardFund.reward_balance,
+      rate,
       value * 100,
     );
     this.setState({ sliderValue: value, voteWorth });

--- a/src/client/helpers/user.js
+++ b/src/client/helpers/user.js
@@ -35,11 +35,12 @@ export const getTotalShares = user =>
 
 export const getHasDefaultSlider = user => getTotalShares(user) >= 10000000;
 
-export const getVoteValue = (user, recentClaims, rewardBalance, weight = 10000) =>
+export const getVoteValue = (user, recentClaims, rewardBalance, rate, weight = 10000) =>
   calculateVoteValue(
     getTotalShares(user),
     parseFloat(recentClaims),
     parseFloat(rewardBalance),
+    rate,
     user.voting_power,
     weight,
   );

--- a/src/client/vendor/steemitHelpers.js
+++ b/src/client/vendor/steemitHelpers.js
@@ -167,11 +167,11 @@ export function getBodyPatchIfSmaller(originalBody, body) {
 /**
  * https://github.com/aaroncox/chainbb/blob/fcb09bee716e907c789a6494975093361482fb4f/services/frontend/src/components/elements/post/button/vote/options.js#L69
  */
-export const calculateVoteValue = (vests, recentClaims, rewardBalance, vp = 10000, weight = 10000) => {
+export const calculateVoteValue = (vests, recentClaims, rewardBalance, rate, vp = 10000, weight = 10000) => {
   const vestingShares = parseInt(vests * 1e6, 10);
   const power = (((vp * weight) / 10000) / 50);
   const rshares = (power * vestingShares) / 10000;
-  return rshares / recentClaims * rewardBalance;
+  return rshares / recentClaims * rewardBalance * rate;
 };
 
 export const calculateTotalDelegatedSP = (user, totalVestingShares, totalVestingFundSteem) => {


### PR DESCRIPTION
Fixes #1057 

Changes:
- Multiply calculated value by current rate.
- Get rate using `get_current_median_history_price`.