### PR TITLE
Support iframe for AMP pages

### DIFF
--- a/src/server/renderers/ampRenderer.js
+++ b/src/server/renderers/ampRenderer.js
@@ -6,6 +6,10 @@ import { getHtml } from '../../client/components/Story/Body';
 
 HandlebarsIntl.registerWith(Handlebars);
 
+function upgradeURL(url) {
+  return url.replace(/^(\/\/)|(http:\/\/)/, 'https://');
+}
+
 function cleanHTML(html) {
   const $ = cheerio.load(html);
   $('head').remove();
@@ -17,6 +21,24 @@ function cleanHTML(html) {
         'src',
       )}"></amp-img></div>`,
     );
+  });
+
+  // AMP requires amp-iframe instead of iframe
+  const allowedIframeAttrs = ['src', 'frameborder', 'allowfullscreen', 'width', 'height'];
+  $('iframe').each((i, elem) => {
+    const el = $('<amp-iframe></amp-iframe>');
+    const attribs = elem.attribs;
+
+    Object.keys(attribs).forEach((key) => {
+      if (allowedIframeAttrs.includes(key)) {
+        const value = key === 'src' ? upgradeURL(attribs[key]) : attribs[key];
+        el.attr(key, value);
+      }
+    });
+
+    el.attr('sandbox', 'allow-scripts allow-same-origin allow-presentation');
+    $(el).append('<span placeholder>Loading iframe</span>');
+    $(elem).replaceWith(el);
   });
 
   return $('body').html();

--- a/src/server/renderers/ampRenderer.js
+++ b/src/server/renderers/ampRenderer.js
@@ -47,7 +47,7 @@ function cleanHTML(html) {
 function getContext(post, body, appUrl) {
   const metadata = _.attempt(JSON.parse, post.json_metadata);
   let images = [];
-  if (!_.isError(metadata)) images = metadata.image;
+  if (!_.isError(metadata) && metadata.image) images = metadata.image;
 
   const datePublished = `${post.created}Z`;
   const dateModified = `${post.last_update}Z`;

--- a/templates/amp_index.hbs
+++ b/templates/amp_index.hbs
@@ -38,6 +38,7 @@
         height: 150px;
       }
     </style>
+    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   </head>
   <body>
     <div class="wrapper">


### PR DESCRIPTION
Fixes #1257

Changes:
- Convert `iframes` to `amp-iframes`.
- Check for `metadata.image` properly.
