### PR TITLE
Remove trailing comma

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "DEBUG": {
       "description": "Debug namespaces for https://github.com/visionmedia/debug.",
       "value": "busy:server",
-      "required": false,
+      "required": false
     }
   },
   "formation": {


### PR DESCRIPTION
Trailing commas make JSON files not correct. This breaks Heroku deployments.

Changes:
- Remove trailing comma from app.json.
