### PR TITLE
Change default translation file

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,3 @@
 files:
-  - source: /src/client/locales/en.json
+  - source: /src/client/locales/default.json
     translation: /src/client/locales/%two_letters_code%.json


### PR DESCRIPTION
Change default translation file from `en.json` to `default.json` on Crowin config file
