### PR TITLE
Use full locale instead of country prefix

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,3 @@
 files:
   - source: /src/client/locales/default.json
-    translation: /src/client/locales/%two_letters_code%.json
+    translation: /src/client/locales/%locale%.json


### PR DESCRIPTION
Use full locale instead of country prefix for translation file
