### PR TITLE
Use lodash find instead of native one

### DIFF
--- a/src/client/components/CommentFooter/CommentFooter.js
+++ b/src/client/components/CommentFooter/CommentFooter.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import find from 'lodash/find';
 import { getHasDefaultSlider, getVoteValue } from '../../helpers/user';
 import Slider from '../Slider/Slider';
 import Buttons from './Buttons';


### PR DESCRIPTION
Fixes #1119

- Import lodash's `find` instead of using native one.