### PR TITLE
Limit links to 10

### DIFF
--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -231,7 +231,7 @@ class Write extends React.Component {
       metaData.users = users;
     }
     if (links.length) {
-      metaData.links = links;
+      metaData.links = links.slice(0, 10);
     }
     if (images.length) {
       metaData.image = images;


### PR DESCRIPTION
Poor's Man SegWit.

Changes:
- Limit links in metadata to 10 so we don't increase TX size potentially (and practically) creating TX that is bigger than block size.
