### PR TITLE
Update Topnav and tooltip z-index

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -167,7 +167,7 @@ export default class Wrapper extends React.PureComponent {
       <IntlProvider key={usedLocale} locale={usedLocale} messages={translations}>
         <LocaleProvider locale={enUS}>
           <Layout data-dir={getLocaleDirection(getAvailableLocale(locale))}>
-            <Layout.Header style={{ position: 'fixed', width: '100%', zIndex: 5 }}>
+            <Layout.Header style={{ position: 'fixed', width: '100%', zIndex: 1050 }}>
               <Topnav username={user.name} onMenuItemClick={this.handleMenuItemClick} />
             </Layout.Header>
             <div className="content">

--- a/src/client/styles/common.less
+++ b/src/client/styles/common.less
@@ -40,8 +40,13 @@ a:focus {
   overflow: hidden;
 }
 
+.ant-modal-mask,
+.ant-modal-wrap {
+  z-index: 1200;
+}
+
 .ant-tooltip {
-  z-index: 999;
+  z-index: 1060;
 
   &-content {
     font-weight: 500;


### PR DESCRIPTION
Fixes #1293 

Changes:
- Set Topnav z-index to 1050 (popover has z-index of 1030)
- Set tooltip z-index to 1060.
