### PR TITLE
Migrate avatars to SteemitImages

### DIFF
--- a/src/client/components/Avatar.js
+++ b/src/client/components/Avatar.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import getImage from '../helpers/getImage';
 import './Avatar.less';
 
 const Avatar = ({ username, size }) => {
@@ -10,10 +9,15 @@ const Avatar = ({ username, size }) => {
     height: `${size}px`,
   };
 
+  const url =
+    size > 64
+      ? `https://steemitimages.com/u/${username}/avatar`
+      : `https://steemitimages.com/u/${username}/avatar/small`;
+
   if (username) {
     style = {
       ...style,
-      backgroundImage: `url(${getImage(`@${username}?width=${size}&height=${size}`)})`,
+      backgroundImage: `url(${url})`,
     };
   }
 

--- a/src/client/components/AvatarLightbox.js
+++ b/src/client/components/AvatarLightbox.js
@@ -1,20 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Lightbox from 'react-image-lightbox';
-import getImage from '../helpers/getImage';
 import Avatar from './Avatar';
 
 export default class AvatarLightbox extends React.Component {
   static propTypes = {
     username: PropTypes.string,
     size: PropTypes.number,
-    previewSize: PropTypes.number,
   };
 
   static defaultProps = {
     username: undefined,
     size: 100,
-    previewSize: 800,
   };
 
   state = {
@@ -26,7 +23,7 @@ export default class AvatarLightbox extends React.Component {
   handleCloseRequest = () => this.setState({ open: false });
 
   render() {
-    const { username, size, previewSize } = this.props;
+    const { username, size } = this.props;
 
     return (
       <div>
@@ -35,7 +32,7 @@ export default class AvatarLightbox extends React.Component {
         </a>
         {this.state.open && (
           <Lightbox
-            mainSrc={getImage(`@${username}?crop=limit&s=${previewSize}`)}
+            mainSrc={`https://steemitimages.com/u/${username}/avatar/large`}
             onCloseRequest={this.handleCloseRequest}
           />
         )}

--- a/src/client/components/UserHeader.js
+++ b/src/client/components/UserHeader.js
@@ -25,7 +25,9 @@ const UserHeader = ({
   onSelect,
   handleVisibleChange,
 }) => {
-  const style = hasCover ? { backgroundImage: `url("${coverImage}")` } : {};
+  const style = hasCover
+    ? { backgroundImage: `url("https://steemitimages.com/2048x512/${coverImage}")` }
+    : {};
   return (
     <div className={classNames('UserHeader', { 'UserHeader--cover': hasCover })} style={style}>
       <div className="UserHeader__container">

--- a/src/client/components/UserHeader.js
+++ b/src/client/components/UserHeader.js
@@ -29,7 +29,7 @@ const UserHeader = ({
   return (
     <div className={classNames('UserHeader', { 'UserHeader--cover': hasCover })} style={style}>
       <div className="UserHeader__container">
-        <AvatarLightbox username={handle} size={100} previewSize={800} />
+        <AvatarLightbox username={handle} size={100} />
         <div className="UserHeader__user">
           <div className="UserHeader__row">
             <h2 className="UserHeader__user__username">


### PR DESCRIPTION
Fixes #1302.

Changes:
- Avatars now use SteemitImages instead of BusyIMG.
- Lightbox uses large avatar from SteemitImages.
