### PR TITLE
add Scrollbars to CommentFooter

### DIFF
--- a/src/client/components/CommentFooter/CommentFooter.js
+++ b/src/client/components/CommentFooter/CommentFooter.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import find from 'lodash/find';
+import { Scrollbars } from 'react-custom-scrollbars';
 import { getHasDefaultSlider, getVoteValue } from '../../helpers/user';
 import Slider from '../Slider/Slider';
 import Buttons from './Buttons';

--- a/src/client/components/CommentFooter/CommentFooter.js
+++ b/src/client/components/CommentFooter/CommentFooter.js
@@ -143,16 +143,18 @@ export default class CommentFooter extends React.Component {
     }
 
     return (
-      <div className="CommentFooter">
-        {actionPanel}
-        {sliderVisible && (
-          <Slider
-            value={this.state.sliderValue}
-            voteWorth={this.state.voteWorth}
-            onChange={this.handleSliderChange}
-          />
-        )}
-      </div>
+      <Scrollbars universal autoHide style={{ width: '100%', height: 35 }}>
+        <div className="CommentFooter">
+          {actionPanel}
+          {sliderVisible && (
+            <Slider
+              value={this.state.sliderValue}
+              voteWorth={this.state.voteWorth}
+              onChange={this.handleSliderChange}
+            />
+          )}
+        </div>
+      </Scrollbars>
     );
   }
 }

--- a/src/client/components/CommentFooter/CommentFooter.less
+++ b/src/client/components/CommentFooter/CommentFooter.less
@@ -4,6 +4,7 @@
   padding: 8px 0;
   color: @blue-botticelli;
   line-height: 14px;
+  width: max-content;
 
   &__payout {
     font-weight: bold;


### PR DESCRIPTION
Fixes #1036

In my last PR it seem that breaking comment actions in two line take alot of space , so in this one i suggest this changement by adding antd scrollbars to comment actions . 
As the issue is in the mobile view , we can use this feature temporarily untill we have a better solution .

- Changes on ; busy/src/client/components/CommentFooter/CommentFooter.js
### Adding scrollbars module & implent it.
- Changes on ; busy/src/client/components/CommentFooter/CommentFooter.lss
### force full width to commentFooter