### PR TITLE
Generate accurate metadata and refactor image lightbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "lightrpc": "0.0.1",
     "lodash": "^4.0.0",
     "lodash-webpack-plugin": "^0.11.4",
-    "marked": "^0.3.6",
     "matchmedia": "^0.1.2",
     "morgan": "^1.8.2",
     "newrelic": "^1.40.0",

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -18,7 +18,7 @@ import { getFromMetadata, extractImages } from '../../helpers/parser';
 import { isPostDeleted } from '../../helpers/postHelpers';
 import withAuthActions from '../../auth/withAuthActions';
 import { getProxyImageURL } from '../../helpers/image';
-import Body, { remarkable } from './Body';
+import Body, { getHtml } from './Body';
 import StoryDeleted from './StoryDeleted';
 import StoryFooter from '../StoryFooter/StoryFooter';
 import Avatar from '../Avatar';
@@ -185,7 +185,7 @@ class StoryFull extends React.Component {
 
     const { open, index } = this.state.lightbox;
 
-    const parsedBody = remarkable.render(post.body);
+    const parsedBody = getHtml(post.body, {}, 'text');
 
     this.images = extractImages(parsedBody);
 

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -11,11 +11,10 @@ import {
   FormattedNumber,
 } from 'react-intl';
 import { Link } from 'react-router-dom';
-import cheerio from 'cheerio';
 import { Tag, Icon, Popover, Tooltip } from 'antd';
 import Lightbox from 'react-image-lightbox';
 import formatter from '../../helpers/steemitFormatter';
-import { getFromMetadata } from '../../helpers/parser';
+import { getFromMetadata, extractImages } from '../../helpers/parser';
 import { isPostDeleted } from '../../helpers/postHelpers';
 import withAuthActions from '../../auth/withAuthActions';
 import { getProxyImageURL } from '../../helpers/image';
@@ -186,10 +185,9 @@ class StoryFull extends React.Component {
 
     const { open, index } = this.state.lightbox;
 
-    const $ = cheerio.load(remarkable.render(post.body));
-    $('img').each((id, el) => {
-      this.images.push(`https://steemitimages.com/0x0/${$(el).attr('src')}`);
-    });
+    const parsedBody = remarkable.render(post.body);
+
+    this.images = extractImages(parsedBody);
 
     const tags = _.union(getFromMetadata(post.json_metadata, 'tags'), [post.category]);
 

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -11,6 +11,7 @@ import {
   FormattedNumber,
 } from 'react-intl';
 import { Link } from 'react-router-dom';
+import cheerio from 'cheerio';
 import { Tag, Icon, Popover, Tooltip } from 'antd';
 import Lightbox from 'react-image-lightbox';
 import formatter from '../../helpers/steemitFormatter';
@@ -18,7 +19,7 @@ import { getFromMetadata } from '../../helpers/parser';
 import { isPostDeleted } from '../../helpers/postHelpers';
 import withAuthActions from '../../auth/withAuthActions';
 import { getProxyImageURL } from '../../helpers/image';
-import Body from './Body';
+import Body, { remarkable } from './Body';
 import StoryDeleted from './StoryDeleted';
 import StoryFooter from '../StoryFooter/StoryFooter';
 import Avatar from '../Avatar';
@@ -80,6 +81,8 @@ class StoryFull extends React.Component {
         index: 0,
       },
     };
+
+    this.images = [];
 
     this.handleClick = this.handleClick.bind(this);
     this.handleContentClick = this.handleContentClick.bind(this);
@@ -182,7 +185,12 @@ class StoryFull extends React.Component {
     } = this.props;
 
     const { open, index } = this.state.lightbox;
-    this.images = getFromMetadata(post.json_metadata, 'image');
+
+    const $ = cheerio.load(remarkable.render(post.body));
+    $('img').each((id, el) => {
+      this.images.push(`https://steemitimages.com/0x0/${$(el).attr('src')}`);
+    });
+
     const tags = _.union(getFromMetadata(post.json_metadata, 'tags'), [post.category]);
 
     let followText = '';

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -120,6 +120,7 @@ class StoryFull extends React.Component {
       const tags = this.contentDiv.getElementsByTagName('img');
       for (let i = 0; i < tags.length; i += 1) {
         if (tags[i] === e.target && this.images.length > i) {
+          if (e.target.parentNode && e.target.parentNode.tagName === 'A') return;
           this.setState({
             lightbox: {
               open: true,

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -393,7 +393,7 @@ class StoryFull extends React.Component {
             <i className="iconfont icon-more StoryFull__header__more" />
           </Popover>
         </div>
-        {content}
+        <div className="StoryFull__content">{content}</div>
         {open && (
           <Lightbox
             mainSrc={this.images[index]}

--- a/src/client/components/Story/StoryFull.less
+++ b/src/client/components/Story/StoryFull.less
@@ -97,6 +97,10 @@
       }
     }
   }
+
+  &__content img {
+    cursor: pointer;
+  }
 }
 div[data-dir='rtl'] .StoryFull {
   &__header {

--- a/src/client/helpers/parser.js
+++ b/src/client/helpers/parser.js
@@ -7,4 +7,27 @@ export function getFromMetadata(jsonMetadata, key) {
   return _.get(metadata, key);
 }
 
+const imgRegex = /<img[^>]+src="([^">]+)"/g;
+const hrefRegex = /<a[^>]+href="([^">]+)"/g;
+
+function extract(body, regex) {
+  const matches = [];
+
+  let match;
+  do {
+    match = regex.exec(body);
+    if (match) matches.push(match[1]);
+  } while (match);
+
+  return matches;
+}
+
+export function extractImages(body) {
+  return extract(body, imgRegex);
+}
+
+export function extractLinks(body) {
+  return extract(body, hrefRegex);
+}
+
 export default null;

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -9,7 +9,7 @@ import isArray from 'lodash/isArray';
 import 'url-search-params-polyfill';
 import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
-import { remarkable } from '../../components/Story/Body';
+import { getHtml } from '../../components/Story/Body';
 import { extractImages, extractLinks } from '../../helpers/parser';
 import { rewardsValues } from '../../../common/constants/rewards';
 import GetBoost from '../../components/Sidebar/GetBoost';
@@ -181,7 +181,7 @@ class Write extends React.Component {
       }
     }
 
-    const parsedBody = remarkable.render(postBody);
+    const parsedBody = getHtml(postBody, {}, 'text');
 
     const images = extractImages(parsedBody);
     const links = extractLinks(parsedBody);

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { replace } from 'react-router-redux';
-import marked from 'marked';
+import cheerio from 'cheerio';
 import kebabCase from 'lodash/kebabCase';
 import debounce from 'lodash/debounce';
 import isArray from 'lodash/isArray';
 import 'url-search-params-polyfill';
 import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
+import { remarkable } from '../../components/Story/Body';
 import { rewardsValues } from '../../../common/constants/rewards';
 import GetBoost from '../../components/Sidebar/GetBoost';
 import DeleteDraftModal from './DeleteDraftModal';
@@ -182,19 +183,15 @@ class Write extends React.Component {
       }
     }
 
-    const renderer = new marked.Renderer();
+    const $ = cheerio.load(remarkable.render(postBody));
 
-    renderer.link = href => {
-      links.push(href);
-      return marked.Renderer.prototype.link.apply(renderer, arguments);
-    };
+    $('a').each((_, el) => {
+      links.push($(el).attr('href'));
+    });
 
-    renderer.image = href => {
-      images.push(href);
-      return marked.Renderer.prototype.image.apply(renderer, arguments);
-    };
-
-    marked(postBody || '', { renderer });
+    $('img').each((_, el) => {
+      images.push($(el).attr('src'));
+    });
 
     if (data.title && !this.permlink) {
       data.permlink = kebabCase(data.title);

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { replace } from 'react-router-redux';
-import cheerio from 'cheerio';
 import kebabCase from 'lodash/kebabCase';
 import debounce from 'lodash/debounce';
 import isArray from 'lodash/isArray';
@@ -11,6 +10,7 @@ import 'url-search-params-polyfill';
 import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
 import { remarkable } from '../../components/Story/Body';
+import { extractImages, extractLinks } from '../../helpers/parser';
 import { rewardsValues } from '../../../common/constants/rewards';
 import GetBoost from '../../components/Sidebar/GetBoost';
 import DeleteDraftModal from './DeleteDraftModal';
@@ -170,8 +170,6 @@ class Write extends React.Component {
     const tags = form.topics;
     const users = [];
     const userRegex = /@([a-zA-Z.0-9-]+)/g;
-    const links = [];
-    const images = [];
     let matches;
 
     const postBody = data.body;
@@ -183,15 +181,10 @@ class Write extends React.Component {
       }
     }
 
-    const $ = cheerio.load(remarkable.render(postBody));
+    const parsedBody = remarkable.render(postBody);
 
-    $('a').each((_, el) => {
-      links.push($(el).attr('href'));
-    });
-
-    $('img').each((_, el) => {
-      images.push($(el).attr('src'));
-    });
+    const images = extractImages(parsedBody);
+    const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {
       data.permlink = kebabCase(data.title);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,10 +5465,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.3.6:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
-
 matchmedia@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/matchmedia/-/matchmedia-0.1.2.tgz#cfd47f2bf68fbc7f5ea1bd3a3cf1715ecba3c1bd"


### PR DESCRIPTION
Fixes #848 
Fixes #829 
Fixes #1366

Changes:
- Don't open images that are direct child of link.
- When generating post metadata use regex to extract links and images (current solution ignores HTML links and images).
- Use regex to extract images from post instead of using metadata as it might be incomplete (e.g. this post is missing images in metadata so lightbox won't open: https://staging.busy.org/piston/@xeroc/piston-web-first-open-source-steem-gui---searching-for-alpha-testers)
