### PR TITLE
Fix for preview image not found

### DIFF
--- a/src/client/components/Story/StoryPreview.js
+++ b/src/client/components/Story/StoryPreview.js
@@ -55,7 +55,7 @@ const StoryPreview = ({ post }) => {
 
     image: () => (
       <div key={imagePath} className="Story__content__img-container">
-        <img alt="post" src={imagePath} />
+        <img alt="" src={imagePath} />
       </div>
     ),
   };


### PR DESCRIPTION
Fixes #1319 

Changes:
- Remove alt tag on image preview to be an empty string, instead of the word "post"
