### PR TITLE
Add error check incase asksteem fails for search

### DIFF
--- a/src/client/search/searchActions.js
+++ b/src/client/search/searchActions.js
@@ -10,13 +10,15 @@ export const searchAskSteem = search => dispatch =>
     type: SEARCH_ASK_STEEM.ACTION,
     payload: {
       promise: Promise.all([
-        getAllSearchResultPages(search).then(response => {
-          let mergedResults = [];
-          _.each(response, element => {
-            mergedResults = _.concat(mergedResults, element.results);
-          });
-          return _.reverse(_.sortBy(mergedResults, ['type', 'created']));
-        }),
+        getAllSearchResultPages(search)
+          .then(response => {
+            let mergedResults = [];
+            _.each(response, element => {
+              mergedResults = _.concat(mergedResults, element.results);
+            });
+            return _.reverse(_.sortBy(mergedResults, ['type', 'created']));
+          })
+          .catch(() => []),
         getAccountReputation(search),
       ]),
     },

--- a/src/client/search/searchReducer.js
+++ b/src/client/search/searchReducer.js
@@ -3,7 +3,7 @@ import * as searchActions from './searchActions';
 import formatter from '../helpers/steemitFormatter';
 
 const initialState = {
-  loading: false,
+  loading: true,
   searchError: false,
   searchResults: [],
   autoCompleteSearchResults: [],


### PR DESCRIPTION
Fixes # 
Sometimes AskSteem is down, causing search to completely fail and not rely on steem for other results. See here https://staging.busy.org/search?q=jm90mm vs this PR

Changes:
- Add catch block for askSteem to return an empty array rather than throw an error


