### PR TITLE
Remove promoted from TopicSelector, Style Updates, Error Checks to SC2.me

### DIFF
--- a/src/client/auth/authActions.js
+++ b/src/client/auth/authActions.js
@@ -1,4 +1,5 @@
 import Cookie from 'js-cookie';
+import { createAction } from 'redux-actions';
 import { getIsAuthenticated } from '../reducers';
 import { getAccount } from '../helpers/apiHelpers';
 import { getFollowing } from '../user/userActions';
@@ -21,12 +22,14 @@ export const LOGOUT_SUCCESS = '@auth/LOGOUT_SUCCESS';
 
 export const UPDATE_AUTH_USER = createAsyncActionType('@auth/UPDATE_AUTH_USER');
 
+const loginError = createAction(LOGIN_ERROR);
+
 export const login = () => (dispatch, getState, { steemConnectAPI }) => {
   let promise = Promise.resolve(null);
   if (!steemConnectAPI.options.accessToken) {
     promise = Promise.reject(new Error('There is not accessToken present'));
   } else {
-    promise = steemConnectAPI.me();
+    promise = steemConnectAPI.me().catch(() => dispatch(loginError()));
   }
   if (getIsAuthenticated(getState())) promise = Promise.resolve(null);
 
@@ -38,7 +41,7 @@ export const login = () => (dispatch, getState, { steemConnectAPI }) => {
     meta: {
       refresh: getIsAuthenticated(getState()),
     },
-  }).catch(() => {});
+  }).catch(() => dispatch(loginError()));
 };
 
 export const getCurrentUserFollowing = () => dispatch => dispatch(getFollowing());

--- a/src/client/components/Comments/Comment.less
+++ b/src/client/components/Comments/Comment.less
@@ -39,7 +39,6 @@
   &__visibility {
     visibility: hidden;
     position: absolute;
-    top: -8px;
     right: 0;
     z-index: 1;
 

--- a/src/client/components/Sidebar/PostRecommendation.less
+++ b/src/client/components/Sidebar/PostRecommendation.less
@@ -33,6 +33,7 @@
       font-size: 16px;
       font-weight: bold;
       margin-right: 10px;
+      max-width: 175px;
 
       &:hover {
         color: @black !important;

--- a/src/client/components/TopicSelector.js
+++ b/src/client/components/TopicSelector.js
@@ -74,9 +74,6 @@ class TopicSelector extends React.Component {
                 <PopoverMenuItem key="hot">
                   <FormattedMessage id="sort_hot" defaultMessage="Hot" />
                 </PopoverMenuItem>
-                <PopoverMenuItem key="promoted">
-                  <FormattedMessage id="sort_promoted" defaultMessage="Promoted" />
-                </PopoverMenuItem>
               </PopoverMenu>
             }
           >

--- a/src/client/components/__tests__/__snapshots__/TopicSelector.js.snap
+++ b/src/client/components/__tests__/__snapshots__/TopicSelector.js.snap
@@ -123,19 +123,6 @@ ShallowWrapper {
                     values={Object {}}
                   />
                 </PopoverMenuItem>
-                <PopoverMenuItem
-                  bold={true}
-                  disabled={false}
-                  fullScreenHidden={false}
-                  itemKey=""
-                  onClick={[Function]}
-                >
-                  <FormattedMessage
-                    defaultMessage="Promoted"
-                    id="sort_promoted"
-                    values={Object {}}
-                  />
-                </PopoverMenuItem>
               </PopoverMenu>
             }
             mouseEnterDelay={0.1}
@@ -314,19 +301,6 @@ ShallowWrapper {
                       values={Object {}}
                     />
                   </PopoverMenuItem>
-                  <PopoverMenuItem
-                    bold={true}
-                    disabled={false}
-                    fullScreenHidden={false}
-                    itemKey=""
-                    onClick={[Function]}
-                  >
-                    <FormattedMessage
-                      defaultMessage="Promoted"
-                      id="sort_promoted"
-                      values={Object {}}
-                    />
-                  </PopoverMenuItem>
                 </PopoverMenu>
               }
               mouseEnterDelay={0.1}
@@ -455,19 +429,6 @@ ShallowWrapper {
                   <FormattedMessage
                     defaultMessage="Hot"
                     id="sort_hot"
-                    values={Object {}}
-                  />
-                </PopoverMenuItem>
-                <PopoverMenuItem
-                  bold={true}
-                  disabled={false}
-                  fullScreenHidden={false}
-                  itemKey=""
-                  onClick={[Function]}
-                >
-                  <FormattedMessage
-                    defaultMessage="Promoted"
-                    id="sort_promoted"
                     values={Object {}}
                   />
                 </PopoverMenuItem>
@@ -633,19 +594,6 @@ ShallowWrapper {
                     <FormattedMessage
                       defaultMessage="Hot"
                       id="sort_hot"
-                      values={Object {}}
-                    />
-                  </PopoverMenuItem>
-                  <PopoverMenuItem
-                    bold={true}
-                    disabled={false}
-                    fullScreenHidden={false}
-                    itemKey=""
-                    onClick={[Function]}
-                  >
-                    <FormattedMessage
-                      defaultMessage="Promoted"
-                      id="sort_promoted"
                       values={Object {}}
                     />
                   </PopoverMenuItem>
@@ -827,19 +775,6 @@ ShallowWrapper {
                         values={Object {}}
                       />
                     </PopoverMenuItem>
-                    <PopoverMenuItem
-                      bold={true}
-                      disabled={false}
-                      fullScreenHidden={false}
-                      itemKey=""
-                      onClick={[Function]}
-                    >
-                      <FormattedMessage
-                        defaultMessage="Promoted"
-                        id="sort_promoted"
-                        values={Object {}}
-                      />
-                    </PopoverMenuItem>
                   </PopoverMenu>
                 }
                 mouseEnterDelay={0.1}
@@ -968,19 +903,6 @@ ShallowWrapper {
                     <FormattedMessage
                       defaultMessage="Hot"
                       id="sort_hot"
-                      values={Object {}}
-                    />
-                  </PopoverMenuItem>
-                  <PopoverMenuItem
-                    bold={true}
-                    disabled={false}
-                    fullScreenHidden={false}
-                    itemKey=""
-                    onClick={[Function]}
-                  >
-                    <FormattedMessage
-                      defaultMessage="Promoted"
-                      id="sort_promoted"
                       values={Object {}}
                     />
                   </PopoverMenuItem>


### PR DESCRIPTION
Fixes #1373.

Changes:
- Remove promoted from TopicSelector
- Fix for comment collapse icon visibility (Remove negative top styles)
- Fix for PostRecommendation title from overflowing (Add max-width to post-title for flex-wrap)
- Add error checks for SteemConnectAPI.me for timeout
