### PR TITLE
Always call login for side-effects

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -6,7 +6,6 @@ import { withRouter } from 'react-router-dom';
 import { renderRoutes } from 'react-router-config';
 import { LocaleProvider, Layout } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
-import Cookie from 'js-cookie';
 import { getAvailableLocale, getTranslationsByLocale, getLocaleDirection } from './translations';
 import {
   getIsLoaded,
@@ -88,9 +87,7 @@ export default class Wrapper extends React.PureComponent {
   componentDidMount() {
     const { loaded, locale, usedLocale } = this.props;
 
-    if (Cookie.get('access_token')) {
-      this.props.login().then(() => this.props.getFollowing());
-    }
+    this.props.login().then(() => this.props.getFollowing());
 
     this.props.getRewardFund();
     this.props.getRebloggedList();

--- a/src/client/auth/authActions.js
+++ b/src/client/auth/authActions.js
@@ -26,12 +26,14 @@ const loginError = createAction(LOGIN_ERROR);
 
 export const login = () => (dispatch, getState, { steemConnectAPI }) => {
   let promise = Promise.resolve(null);
-  if (!steemConnectAPI.options.accessToken) {
+
+  if (getIsAuthenticated(getState())) {
+    promise = Promise.resolve(null);
+  } else if (!steemConnectAPI.options.accessToken) {
     promise = Promise.reject(new Error('There is not accessToken present'));
   } else {
     promise = steemConnectAPI.me().catch(() => dispatch(loginError()));
   }
-  if (getIsAuthenticated(getState())) promise = Promise.resolve(null);
 
   return dispatch({
     type: LOGIN,

--- a/src/client/user/userActions.js
+++ b/src/client/user/userActions.js
@@ -115,7 +115,7 @@ export const getFollowing = username => (dispatch, getState) => {
   const state = getState();
 
   if (!username && !getIsAuthenticated(state)) {
-    return Promise.reject(new Error('User is not authenticated'));
+    return dispatch({ type: GET_FOLLOWING_ERROR });
   }
 
   const targetUsername = username || getAuthenticatedUserName(state);


### PR DESCRIPTION
Fixes #1387 

Changes:
- Call `login` always for side-effects.
- Dispatch `GET_FOLLOWING_ERROR` instead of throwing.