### PR TITLE
Translate comment notifications

### DIFF
--- a/src/client/comments/commentsActions.js
+++ b/src/client/comments/commentsActions.js
@@ -162,7 +162,6 @@ export const sendComment = (parentPost, body, isUpdating = false, originalCommen
           author: resp.result.operations[0][1].author,
           permlink: resp.result.operations[0][1].permlink,
         };
-        dispatch(notify('Comment submitted successfully', 'success'));
         dispatch(getComments(id, true, focusedComment));
 
         if (window.analytics) {

--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -9,7 +9,7 @@ import {
   FormattedTime,
   FormattedMessage,
 } from 'react-intl';
-import { Tag, Tooltip } from 'antd';
+import { Tag, Tooltip, message } from 'antd';
 import formatter from '../../helpers/steemitFormatter';
 import { MAXIMUM_UPLOAD_SIZE_HUMAN } from '../../helpers/image';
 import { sortComments } from '../../helpers/sortHelpers';
@@ -72,6 +72,8 @@ class Comment extends React.Component {
       commentFormText: '',
       showHiddenComment: false,
     };
+
+    this.handleSubmitComment = this.handleSubmitComment.bind(this);
   }
 
   componentDidMount() {
@@ -149,12 +151,30 @@ class Comment extends React.Component {
     );
   };
 
-  handleSubmitComment = (parentPost, commentValue, isUpdating, originalComment) => {
+  handleSubmitComment(parentPost, commentValue, isUpdating, originalComment) {
+    const { intl } = this.props;
+
     this.setState({ showCommentFormLoading: true });
 
     return this.props
       .onSendComment(parentPost, commentValue, isUpdating, originalComment)
       .then(() => {
+        if (isUpdating) {
+          message.success(
+            intl.formatMessage({
+              id: 'notify_comment_updated',
+              defaultMessage: 'Comment updated',
+            }),
+          );
+        } else {
+          message.success(
+            intl.formatMessage({
+              id: 'notify_comment_sent',
+              defaultMessage: 'Comment submitted',
+            }),
+          );
+        }
+
         this.setState({
           showCommentFormLoading: false,
           replyOpen: false,
@@ -170,7 +190,7 @@ class Comment extends React.Component {
           commentFormText: commentValue,
         });
       });
-  };
+  }
 
   handleEditComment = (parentPost, commentValue) => {
     this.handleSubmitComment(parentPost, commentValue, true, this.props.comment);

--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { injectIntl, FormattedMessage } from 'react-intl';
+import { message } from 'antd';
 import { MAXIMUM_UPLOAD_SIZE_HUMAN } from '../../helpers/image';
 import { sortComments } from '../../helpers/sortHelpers';
 import Loading from '../Icon/Loading';
@@ -128,11 +129,20 @@ class Comments extends React.Component {
     );
   };
 
-  submitComment = (parentPost, commentValue) => {
+  handleSubmitComment(parentPost, commentValue) {
+    const { intl } = this.props;
+
     this.setState({ showCommentFormLoading: true });
     return this.props
       .onSendComment(parentPost, commentValue)
       .then(() => {
+        message.success(
+          intl.formatMessage({
+            id: 'notify_comment_sent',
+            defaultMessage: 'Comment submitted',
+          }),
+        );
+
         this.setState({
           showCommentFormLoading: false,
           commentFormText: '',
@@ -145,7 +155,7 @@ class Comments extends React.Component {
           commentFormText: commentValue,
         });
       });
-  };
+  }
 
   render() {
     const {
@@ -194,7 +204,7 @@ class Comments extends React.Component {
             top
             parentPost={this.props.parentPost}
             username={username}
-            onSubmit={this.submitComment}
+            onSubmit={this.handleSubmitComment}
             isLoading={this.state.showCommentFormLoading}
             inputValue={this.state.commentFormText}
             submitted={this.state.commentSubmitted}

--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -77,6 +77,8 @@
   "comment_send_progress": "Commenting",
   "comment_update_send": "Update comment",
   "comment_update_progress": "Updating",
+  "notify_comment_sent": "Comment submitted",
+  "notify_comment_updated": "Comment updated",
   "reblog": "Reblog",
   "reblog_reblogged": "You already reblogged this post",
   "reblog_modal_title": "Reblog this post?",


### PR DESCRIPTION
Fixes #1422 

Changes:
- Translate `Comment submitted successfully` message.
- Add `Comment updated` message.
