### PR TITLE
Use OLDEST sort if comments have no votes

### DIFF
--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -55,20 +55,45 @@ class Comments extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.state = {
       sort: 'BEST',
       showCommentFormLoading: false,
       commentFormText: '',
       commentSubmitted: false,
     };
+
+    this.detectSort = this.detectSort.bind(this);
+    this.setSort = this.setSort.bind(this);
+  }
+
+  componentDidMount() {
+    this.detectSort(this.props.comments);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.detectSort(nextProps.comments);
+  }
+
+  setSort(sort) {
+    this.setState({
+      sort,
+    });
+  }
+
+  detectSort(comments) {
+    if (
+      comments.length > 0 &&
+      comments.filter(comment => comment.active_votes.length > 0).length === 0
+    ) {
+      this.setSort('OLDEST');
+    }
   }
 
   handleSortClick = e => {
     const type = e.target.parentNode && e.target.parentNode.dataset.type;
     if (type) {
-      this.setState({
-        sort: type,
-      });
+      this.setSort(type);
     }
   };
 

--- a/src/client/components/Comments/Comments.less
+++ b/src/client/components/Comments/Comments.less
@@ -18,7 +18,7 @@
       & > a {
         margin: 0 8px;
         font-weight: bold;
-        color: @purple !important;
+        color: @blue-botticelli !important;
 
         &:hover {
           color: @purple !important;


### PR DESCRIPTION
Fixes #1421 

Changes:
- Set default colour for sort back to grey.
- Use OLDEST sort if comments have no votes.
