### PR TITLE
Allow editing comments from within feed

### DIFF
--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -76,8 +76,13 @@ class Comment extends React.Component {
 
   componentDidMount() {
     const { comment } = this.props;
+    const { hash } = window.location;
+
     const anchorLink = `#@${comment.author}/${comment.permlink}`;
-    if (window.location.hash === anchorLink || comment.focus) {
+    if (hash.indexOf(anchorLink) === 0 || comment.focus) {
+      if (hash.endsWith('-edit')) {
+        this.handleEditClick();
+      }
       this.focus();
     }
   }

--- a/src/client/components/Comments/Comment.less
+++ b/src/client/components/Comments/Comment.less
@@ -24,6 +24,7 @@
   position: relative;
   display: flex;
   margin-top: 16px;
+  margin-right: 4px; // for focus shadow
 
   &--focus {
     animation-timing-function: ease-in-out;

--- a/src/client/components/Story/Story.js
+++ b/src/client/components/Story/Story.js
@@ -220,12 +220,8 @@ class Story extends React.Component {
           <div className="Story__content">
             <Link to={post.url} className="Story__content__title">
               <h2>
-                {post.title || (
-                  <span>
-                    <Tag color="#4f545c">RE</Tag>
-                    {post.root_title}
-                  </span>
-                )}
+                {post.depth !== 0 && <Tag color="#4f545c">RE</Tag>}
+                {post.title || post.root_title}
               </h2>
             </Link>
             {showStoryPreview ? (

--- a/src/client/components/StoryFooter/Buttons.js
+++ b/src/client/components/StoryFooter/Buttons.js
@@ -31,7 +31,6 @@ export default class Buttons extends React.Component {
     saving: PropTypes.bool,
     onLikeClick: PropTypes.func,
     onShareClick: PropTypes.func,
-    onEditClick: PropTypes.func,
     handlePostPopoverMenuClick: PropTypes.func,
   };
 
@@ -44,7 +43,6 @@ export default class Buttons extends React.Component {
     saving: false,
     onLikeClick: () => {},
     onShareClick: () => {},
-    onEditClick: () => {},
     handlePostPopoverMenuClick: () => {},
   };
 
@@ -75,7 +73,6 @@ export default class Buttons extends React.Component {
     this.handleShareCancel = this.handleShareCancel.bind(this);
     this.handleShowReactions = this.handleShowReactions.bind(this);
     this.handleCloseReactions = this.handleCloseReactions.bind(this);
-    this.handleEdit = this.handleEdit.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -128,13 +125,6 @@ export default class Buttons extends React.Component {
     this.setState({
       reactionsModalVisible: false,
     });
-  }
-
-  handleEdit() {
-    this.setState({
-      loadingEdit: true,
-    });
-    this.props.onEditClick();
   }
 
   renderPostPopoverMenu() {

--- a/src/client/feed/Feed.js
+++ b/src/client/feed/Feed.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import _ from 'lodash';
 import ReduxInfiniteScroll from '../vendor/ReduxInfiniteScroll';
 import { getHasDefaultSlider } from '../helpers/user';
@@ -54,6 +55,7 @@ import './Feed.less';
     reblog: reblogActions.reblog,
     followUser,
     unfollowUser,
+    push,
   },
 )
 export default class Feed extends React.Component {
@@ -81,6 +83,7 @@ export default class Feed extends React.Component {
     followUser: PropTypes.func,
     unfollowUser: PropTypes.func,
     loadMoreContent: PropTypes.func,
+    push: PropTypes.func,
   };
 
   static defaultProps = {
@@ -94,6 +97,7 @@ export default class Feed extends React.Component {
     followUser: () => {},
     unfollowUser: () => {},
     loadMoreContent: () => {},
+    push: () => {},
   };
 
   constructor(props) {
@@ -131,8 +135,11 @@ export default class Feed extends React.Component {
     }
   };
 
-  handleEditClick = post => this.props.editPost(post);
-
+  handleEditClick = post => {
+    if (post.depth === 0) return this.props.editPost(post);
+    this.props.push(`${post.url}-edit`);
+    return Promise.resolve(null);
+  };
   render() {
     const {
       user,

--- a/src/client/post/PostContent.js
+++ b/src/client/post/PostContent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import find from 'lodash/find';
 import { Helmet } from 'react-helmet';
 import sanitize from 'sanitize-html';
@@ -55,6 +56,7 @@ import StoryFull from '../components/Story/StoryFull';
     toggleBookmark,
     followUser,
     unfollowUser,
+    push,
   },
 )
 class PostContent extends React.Component {
@@ -80,6 +82,7 @@ class PostContent extends React.Component {
     reblog: PropTypes.func,
     followUser: PropTypes.func,
     unfollowUser: PropTypes.func,
+    push: PropTypes.func,
   };
 
   static defaultProps = {
@@ -96,6 +99,7 @@ class PostContent extends React.Component {
     reblog: () => {},
     followUser: () => {},
     unfollowUser: () => {},
+    push: () => {},
   };
 
   constructor(props) {
@@ -142,7 +146,11 @@ class PostContent extends React.Component {
     }
   };
 
-  handleEditClick = post => this.props.editPost(post);
+  handleEditClick = post => {
+    if (post.depth === 0) return this.props.editPost(post);
+    this.props.push(`${post.url}-edit`);
+    return Promise.resolve(null);
+  };
 
   render() {
     const {


### PR DESCRIPTION
Fixes #963 

Changes:
- Update `RE` display (it wasn't showing on some comments).
- Update `Comment` styles to display focus shadow properly.
- Allow editing comments on `@username/comments` page.
- Allow editing comments when viewing it as single post: `/test/@hellosteem/re-hellosteem-re-hellosteem-re-hellosteem-6ekdcf-test-20180130t123425216z`
