### PR TITLE
Add border to avatars and make them circles

### DIFF
--- a/src/client/components/Avatar.less
+++ b/src/client/components/Avatar.less
@@ -1,7 +1,10 @@
+@import (reference) '../styles/custom.less';
+
 .Avatar {
   display: block !important;
   border-radius: 20%;
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 50%;
+  border: 1px solid @white-gainsboro;
 }

--- a/src/client/components/Avatar.less
+++ b/src/client/components/Avatar.less
@@ -2,7 +2,7 @@
 
 .Avatar {
   display: block !important;
-  border-radius: 20%;
+  border-radius: 50%;
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 50%;


### PR DESCRIPTION
Fixes #1374 
Fixes #1433 

We could add add background colour, but it doesn't look well when using avatars with transparency or round avatars. I created version of avatar that work with backgrounds, but with bigger number of comments (~100) it takes 6 seconds to dispatch and handle all the events).

Changes:
- Add border to Avatars.
- Make Avatars circles.