### PR TITLE
Add Signature tool to profile settings

### DIFF
--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -40,6 +40,7 @@ class StoryFull extends React.Component {
     rewardFund: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
     onActionInitiated: PropTypes.func.isRequired,
+    signature: PropTypes.string,
     rewriteLinks: PropTypes.bool,
     pendingLike: PropTypes.bool,
     pendingFlag: PropTypes.bool,
@@ -58,6 +59,7 @@ class StoryFull extends React.Component {
   };
 
   static defaultProps = {
+    signature: null,
     rewriteLinks: false,
     pendingLike: false,
     pendingFlag: false,
@@ -176,6 +178,7 @@ class StoryFull extends React.Component {
       user,
       post,
       postState,
+      signature,
       rewriteLinks,
       pendingLike,
       pendingFlag,
@@ -195,7 +198,12 @@ class StoryFull extends React.Component {
 
     const { open, index } = this.state.lightbox;
 
-    const parsedBody = getHtml(post.body, {}, 'text');
+    let signedBody = post.body;
+    if (signature) {
+      signedBody = `${post.body}<hr>${signature}`;
+    }
+
+    const parsedBody = getHtml(signedBody, {}, 'text');
 
     this.images = extractImages(parsedBody);
 
@@ -325,7 +333,7 @@ class StoryFull extends React.Component {
           <Body
             full
             rewriteLinks={rewriteLinks}
-            body={post.body}
+            body={signedBody}
             json_metadata={post.json_metadata}
           />
         </div>

--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -116,6 +116,7 @@
   "profile_cover": "Cover picture",
   "profile_social_profiles": "Social profiles",
   "profile_social_profile_incorrect": "This doesn't seem to be valid username. Only alphanumeric characters, hyphens, underscores and dots are allowed.",
+  "profile_signature": "Signature",
   "reply": "Reply",
   "edit": "Edit",
   "show_more": "View more",

--- a/src/client/post/PostContent.js
+++ b/src/client/post/PostContent.js
@@ -64,6 +64,7 @@ class PostContent extends React.Component {
   static propTypes = {
     user: PropTypes.shape().isRequired,
     content: PropTypes.shape().isRequired,
+    signature: PropTypes.string,
     pendingLikes: PropTypes.shape(),
     reblogList: PropTypes.arrayOf(PropTypes.number),
     pendingReblogs: PropTypes.arrayOf(PropTypes.number),
@@ -87,6 +88,7 @@ class PostContent extends React.Component {
   };
 
   static defaultProps = {
+    signature: null,
     pendingLikes: {},
     reblogList: [],
     pendingReblogs: [],
@@ -157,6 +159,7 @@ class PostContent extends React.Component {
     const {
       user,
       content,
+      signature,
       pendingLikes,
       reblogList,
       pendingReblogs,
@@ -236,6 +239,7 @@ class PostContent extends React.Component {
           user={user}
           post={content}
           postState={postState}
+          signature={signature}
           commentCount={content.children}
           pendingLike={pendingLike}
           pendingFlag={pendingFlag}

--- a/src/client/settings/ProfileSettings.js
+++ b/src/client/settings/ProfileSettings.js
@@ -8,6 +8,9 @@ import { Form, Input } from 'antd';
 import SteemConnect from '../steemConnectAPI';
 import { getIsReloading, getAuthenticatedUser } from '../reducers';
 import socialProfiles from '../helpers/socialProfiles';
+import withEditor from '../components/Editor/withEditor';
+import EditorInput from '../components/Editor/EditorInput';
+import Body, { remarkable } from '../components/Story/Body';
 import Action from '../components/Button/Action';
 import Affix from '../components/Utils/Affix';
 import LeftSidebar from '../app/Sidebar/LeftSidebar';
@@ -42,16 +45,34 @@ function mapPropsToFields(props) {
 @Form.create({
   mapPropsToFields,
 })
+@withEditor
 export default class ProfileSettings extends React.Component {
   static propTypes = {
     intl: PropTypes.shape().isRequired,
     form: PropTypes.shape().isRequired,
+    onImageUpload: PropTypes.func,
+    onImageInvalid: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onImageUpload: () => {},
+    onImageInvalid: () => {},
   };
 
   constructor(props) {
     super(props);
 
+    this.state = {
+      bodyHTML: '',
+    };
+
+    this.handleSignatureChange = this.handleSignatureChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.renderBody = this.renderBody.bind(this);
+  }
+
+  handleSignatureChange(body) {
+    _.throttle(this.renderBody, 200, { leading: false, trailing: true })(body);
   }
 
   handleSubmit(e) {
@@ -77,8 +98,15 @@ export default class ProfileSettings extends React.Component {
     });
   }
 
+  renderBody(body) {
+    this.setState({
+      bodyHTML: remarkable.render(body),
+    });
+  }
+
   render() {
     const { intl, form } = this.props;
+    const { bodyHTML } = this.state;
     const { getFieldDecorator } = form;
 
     const socialInputs = socialProfiles.map(profile => (
@@ -246,6 +274,37 @@ export default class ProfileSettings extends React.Component {
                     />
                   </h3>
                   <div className="Settings__section__inputs">{socialInputs}</div>
+                </div>
+                <div className="Settings__section">
+                  <h3>
+                    <FormattedMessage
+                      id="profile_social_profiles"
+                      defaultMessage="Social profiles"
+                    />
+                  </h3>
+                  <div className="Settings__section__inputs">
+                    {getFieldDecorator('signature', {
+                      initialValue: '',
+                    })(
+                      <EditorInput
+                        autosize={{ minRows: 3, maxRows: 6 }}
+                        onChange={this.handleSignatureChange}
+                        onImageUpload={this.props.onImageUpload}
+                        onImageInvalid={this.props.onImageInvalid}
+                      />,
+                    )}
+                    {bodyHTML && (
+                      <Form.Item
+                        label={
+                          <span className="Editor__label">
+                            <FormattedMessage id="preview" defaultMessage="Preview" />
+                          </span>
+                        }
+                      >
+                        <Body full body={bodyHTML} />
+                      </Form.Item>
+                    )}
+                  </div>
                 </div>
                 <Action
                   primary

--- a/src/client/settings/ProfileSettings.js
+++ b/src/client/settings/ProfileSettings.js
@@ -277,10 +277,7 @@ export default class ProfileSettings extends React.Component {
                 </div>
                 <div className="Settings__section">
                   <h3>
-                    <FormattedMessage
-                      id="profile_social_profiles"
-                      defaultMessage="Social profiles"
-                    />
+                    <FormattedMessage id="profile_signature" defaultMessage="Signature" />
                   </h3>
                   <div className="Settings__section__inputs">
                     {getFieldDecorator('signature', {
@@ -294,13 +291,7 @@ export default class ProfileSettings extends React.Component {
                       />,
                     )}
                     {bodyHTML && (
-                      <Form.Item
-                        label={
-                          <span className="Editor__label">
-                            <FormattedMessage id="preview" defaultMessage="Preview" />
-                          </span>
-                        }
-                      >
+                      <Form.Item label={<FormattedMessage id="preview" defaultMessage="Preview" />}>
                         <Body full body={bodyHTML} />
                       </Form.Item>
                     )}

--- a/src/client/settings/Settings.less
+++ b/src/client/settings/Settings.less
@@ -14,11 +14,11 @@
       }
     }
 
-    h3:not(:first-of-type) {
+    & > h3:not(:first-of-type) {
       margin-top: 16px;
     }
 
-    p {
+    & > p {
       color: #99aab5;
       &:last-of-type {
         margin-bottom: 4px;


### PR DESCRIPTION
Fixes #1436 

Changes:
- Add Signature tool to user profile settings
- Include signature in user posts.

I couldn't really test it on real signature stored in profile settings, because I don't have active key for hellosteem, and I didn't want to post using my account.
