### PR TITLE
Support trailing slash in UserMenu

### DIFF
--- a/src/client/user/UserHero.js
+++ b/src/client/user/UserHero.js
@@ -18,7 +18,7 @@ class UserMenuWrapper extends React.Component {
   onChange = key => {
     const { match, history } = this.props;
     const section = key === 'discussions' ? '' : `/${key}`;
-    history.push(`${match.url}${section}`);
+    history.push(`${match.url.replace(/\/$/, '')}${section}`);
   };
 
   render() {


### PR DESCRIPTION
Fixes #1472 

Changes:
- Drop trailing commas when building UserMenu links.
