### PR TITLE
Add custom tag for latex

### DIFF
--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import readingTime from 'reading-time';
 import { Checkbox, Form, Input, Select, Button } from 'antd';
 import { rewardsValues } from '../../../common/constants/rewards';
+import improve from '../../helpers/improve';
 import Action from '../Button/Action';
 import requiresLogin from '../../auth/requiresLogin';
 import withEditor from './withEditor';
@@ -145,7 +146,7 @@ class Editor extends React.Component {
 
   setBodyAndRender(body) {
     this.setState({
-      bodyHTML: remarkable.render(body),
+      bodyHTML: remarkable.render(improve(body)),
     });
   }
 

--- a/src/client/helpers/improve.js
+++ b/src/client/helpers/improve.js
@@ -1,0 +1,8 @@
+const latexRegex = /\[\+\]((\n|.)*?)\[\+\]/g;
+
+export default function improve(body) {
+  return body.replace(
+    latexRegex,
+    (match, p1) => `![${p1}](https://latex.codecogs.com/gif.latex?${encodeURI(p1)})`,
+  );
+}

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -10,6 +10,7 @@ import 'url-search-params-polyfill';
 import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
 import { getHtml } from '../../components/Story/Body';
+import improve from '../../helpers/improve';
 import { extractImages, extractLinks } from '../../helpers/parser';
 import { rewardsValues } from '../../../common/constants/rewards';
 import GetBoost from '../../components/Sidebar/GetBoost';
@@ -149,6 +150,7 @@ class Write extends React.Component {
 
   onSubmit = form => {
     const data = this.getNewPostData(form);
+    data.body = improve(data.body);
     if (this.props.draftId) {
       data.draftId = this.props.draftId;
     }


### PR DESCRIPTION
Fixes #1467 

Changes:
- Add `improve` helper that we can use to add custom tags.
- Add `[+]latex[+]` tag to render LaTeX using Codecogs.
- Improve post preview and final contents when submitting.

![image](https://user-images.githubusercontent.com/1968722/35809796-fbe0c7f6-0a89-11e8-8c51-dc97f6b7a177.png)

To add LaTeX to post you can use custom tag:
```
[+]Latex there[+]
```

like this:
```
[+]
f(x) = \int_{-\infty}^\infty
    \hat f(\xi)\,e^{2 \pi i \xi x}
    \,d\xi
[+]
```

Post preview: http://localhost:3000/@hellosteem/testing-custom-latex

This is just custom tag, that will be replaced when adding post so it will work in other clients as well.