### PR TITLE
Add peer dependency so `npm install` works

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,9 @@
     "webpack-dev-server": "~2.9.3",
     "webpack-hot-middleware": "^2.20.0"
   },
+  "peerDependencies": {
+    "react": "15.6.2"
+  },
   "jest": {
     "moduleNameMapper": {
       "\\.((s)css|less)$": "identity-obj-proxy"


### PR DESCRIPTION
I'm in the process of running this locally for the first time.

I had a dependency error when running `npm install`.

This change makes it so `npm install` will work right after cloning as described in the README.