### PR TITLE
Update feed empty check

### DIFF
--- a/src/client/feed/SubFeed.js
+++ b/src/client/feed/SubFeed.js
@@ -144,7 +144,7 @@ class SubFeed extends React.Component {
           hasMore={hasMore}
           loadMoreContent={loadMoreContent}
         />
-        {!content.length && fetched && loaded && <EmptyFeed />}
+        {fetched && loaded && !isFetching && <EmptyFeed />}
       </div>
     );
   }


### PR DESCRIPTION
This fixes bug when EmptyFeed message was shown when feed was loading.

Changes:
- Check if is not fetching when showing  EmptyFeed.
