### PR TITLE
Prevent adding additional margin for images in paragraphs

### DIFF
--- a/src/client/components/Story/Body.less
+++ b/src/client/components/Story/Body.less
@@ -182,6 +182,10 @@
     margin-top: 20px;
   }
 
+  p > img:first-child {
+    margin-top: 0;
+  }
+
   hr {
     clear: both;
     margin: 20px auto;


### PR DESCRIPTION
Fixes #892 

Changes:
- Don't add additional top margin if `img` is first direct child of `p`.
