### PR TITLE
Downgrade sanitize-html to version that doesn't use PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "redux-thunk": "^2.1.0",
     "remarkable": "^1.7.1",
     "resize-observer-polyfill": "^1.4.2",
-    "sanitize-html": "^1.13.0",
+    "sanitize-html": "1.15.0",
     "sc2-sdk": "^1.0.1",
     "secure-random": "^1.1.1",
     "socket.io": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5327,10 +5327,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -5374,10 +5370,6 @@ lodash.keys@^3.1.2:
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.mergewith@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -6678,7 +6670,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.16:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.16:
   version "6.0.16"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
   dependencies:
@@ -8038,16 +8030,12 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sanitize-html@^1.13.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.17.0.tgz#5c95e57044604d4797367efd9152acaf5b087bb4"
+sanitize-html@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.15.0.tgz#d101a62c9fe0347486badc6cd6ed72daa0a82ced"
   dependencies:
-    chalk "^2.3.0"
     htmlparser2 "^3.9.0"
-    lodash.clonedeep "^4.5.0"
     lodash.escaperegexp "^4.1.2"
-    lodash.mergewith "^4.6.0"
-    postcss "^6.0.14"
     srcset "^1.0.0"
     xtend "^4.0.0"
 


### PR DESCRIPTION
Fixes #1465 

It took a while to figure out why suddenly `sanitize-html` became so big. As it turns out it was small when installed with npm, but got way bigger when installed with yarn. It has `PostCSS@6` dependency, which `npm` somehow "ignores", but yarn doesn't.
Author of sanitize-html suggest it doesn't make sense to use sanitization in the browser, so he doesn't care about its size, and recommends DOMPurify (which we can't use, because it works only in browser).
This PR uses sanitize-html version that doesn't use PostCSS.

Changes:
- Downgrade to `sanitize-html@1.15.0`
