### PR TITLE
Configure scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[/src/client/locales/**]
+insert_final_newline = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package.json
+src/client/locales

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+};

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const fs = require('fs');
 const prettier = require('prettier');
-const options = require('./options');
+const options = require('../../.prettierrc.js');
 
 function formatFile(file) {
   const input = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
Now editor should pick up prettier settings from code directly (so they don't have to be configured manually), and locales shouldn't be autoformatted (by prettier and editorconfig).