### PR TITLE
fix(client): update locale check in charts

### DIFF
--- a/src/client/helpers/cryptosHelper.js
+++ b/src/client/helpers/cryptosHelper.js
@@ -24,7 +24,7 @@ export const getCurrentDaysOfTheWeek = currentLocale => {
   const date = new Date();
   date.setDate(date.getDate() - 7);
   const daysOfTheWeek = [];
-  const locale = _.isEmpty(currentLocale) ? window.navigator.language : currentLocale;
+  const locale = currentLocale === 'auto' ? window.navigator.language : currentLocale;
 
   for (let i = 0; i < 7; i += 1) {
     date.setDate(date.getDate() + 1);


### PR DESCRIPTION
Fixes #1525 

Changes:
- If the locale is set to auto we should use navigator language, otherwise, we should use that locale (this causes a crash on Edge).
