### PR TITLE
Add ability to ctrl/cmd click and open new tab to post

### DIFF
--- a/src/client/components/Story/Story.js
+++ b/src/client/components/Story/Story.js
@@ -178,12 +178,18 @@ class Story extends React.Component {
 
   handlePostModalDisplay(e) {
     e.preventDefault();
-
     const { post } = this.props;
     const isReplyPreview = _.isEmpty(post.title);
+    const openInNewTab = _.get(e, 'metaKey', false) || _.get(e, 'ctrlKey', false);
+    const postURL = dropCategory(post.url);
 
     if (isReplyPreview) {
-      this.props.history.push(dropCategory(post.url));
+      this.props.history.push(postURL);
+    } else if (openInNewTab) {
+      if (window) {
+        const url = `${window.location.origin}${postURL}`;
+        window.open(url);
+      }
     } else {
       this.props.showPostModal(post);
     }
@@ -198,9 +204,16 @@ class Story extends React.Component {
     const elementClassName = _.get(e, 'target.className', '');
     const showPostModal =
       elementNodeName !== 'i' && elementClassName !== 'PostFeedEmbed__playButton';
+    const openInNewTab = _.get(e, 'metaKey', false) || _.get(e, 'ctrlKey', false);
+    const postURL = dropCategory(post.url);
 
     if (isReplyPreview) {
-      this.props.history.push(dropCategory(post.url));
+      this.props.history.push(postURL);
+    } else if (openInNewTab && showPostModal) {
+      if (window) {
+        const url = `${window.location.origin}${postURL}`;
+        window.open(url);
+      }
     } else if (showPostModal) {
       this.props.showPostModal(post);
     }


### PR DESCRIPTION
Fixes #1540 

- Ability to control + click  (windows) or command + click (mac) to open new tab for post

Changes:
- add event check for keys pressed while clicking on post title / post preview
