### PR TITLE
Add Chinese Traditional to Settings

### DIFF
--- a/src/client/settings/Settings.js
+++ b/src/client/settings/Settings.js
@@ -160,7 +160,7 @@ export default class Settings extends React.Component {
     'ko-KR': '한국어 - Korean',
     'ja-JP': '日本語 - Japanese',
     'zh-CN': '简体中文 - Simplified Chinese',
-    // zh: '繁體中文 - Traditional Chinese',
+    'zh-TW': '繁體中文 - Traditional Chinese',
   };
 
   handleSave = () => {

--- a/src/client/translations/index.js
+++ b/src/client/translations/index.js
@@ -58,7 +58,7 @@ export const availableLocalesToReactIntl = {
   'vls-BE': '',
   'yo-NG': 'yo',
   'zh-CN': 'zh',
-  'zh-TW': '',
+  'zh-TW': 'zh',
 };
 
 export const rtlLocales = ['he', 'ar', 'far', 'yi', 'ku', 'ur', 'dv', 'ha', 'ps'];


### PR DESCRIPTION
Fixes #1039

Changes:
- Re-add chinese traditional to settings
- Use `zh` for react-intl
    - See here (All `zh-*` is mapped to zh.js): https://github.com/yahoo/intl-relativeformat/blob/master/dist/locale-data/zh.js
