### PR TITLE
Fixed text overlapping in header

### DIFF
--- a/src/client/components/Navigation/Topnav.less
+++ b/src/client/components/Navigation/Topnav.less
@@ -91,8 +91,7 @@
 
       & > li.ant-menu-item {
         height: 55px !important;
-        padding: 0 !important;
-        width: 41px;
+        padding: 0 3px !important;
         display: flex;
         justify-content: center;
         border-bottom: 0 !important;


### PR DESCRIPTION
Fixes # .
Text overlapping in header (in some translations)
Changes:
- Added a little padding to separator
- Deleted fixed width on menu  element(s)
#1585 