### PR TITLE
Pass Sort Key to sub Comments

### DIFF
--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -356,6 +356,7 @@ class Comment extends React.Component {
                   intl={this.props.intl}
                   comment={child}
                   parent={comment}
+                  sort={sort}
                   pendingVotes={pendingVotes}
                   rootPostAuthor={rootPostAuthor}
                   commentsChildren={commentsChildren}


### PR DESCRIPTION
Changes:
- Pass sort key to level 2 comments and down

### Explanation
All comments below the root level were not receiving the sort prop. They were all being sorted by the default prop `BEST`.