### PR TITLE
Render Comments in Chunks WIP

### DIFF
--- a/src/client/comments/Comments.js
+++ b/src/client/comments/Comments.js
@@ -154,29 +154,30 @@ export default class Comments extends React.Component {
       rewriteLinks,
     } = this.props;
     const postId = post.id;
-    let fetchedCommentsList = [];
+    let rootLevelComments = [];
 
-    const rootNode = comments.childrenById[postId];
+    const parentNode = comments.childrenById[postId];
 
-    if (rootNode instanceof Array) {
-      fetchedCommentsList = rootNode.map(id => comments.comments[id]);
+    if (parentNode instanceof Array) {
+      rootLevelComments = parentNode.map(id => comments.comments[id]);
     }
 
     let commentsChildren = {};
 
-    if (fetchedCommentsList && fetchedCommentsList.length) {
+    if (rootLevelComments && rootLevelComments.length) {
       commentsChildren = this.getNestedComments(comments, comments.childrenById[postId], {});
     }
 
     return (
-      fetchedCommentsList && (
+      rootLevelComments && (
         <CommentsList
           user={user}
           parentPost={post}
-          comments={fetchedCommentsList}
+          comments={comments.comments}
+          rootLevelComments={rootLevelComments}
+          commentsChildren={commentsChildren}
           authenticated={this.props.authenticated}
           username={this.props.username}
-          commentsChildren={commentsChildren}
           pendingVotes={pendingVotes}
           loading={comments.isFetching}
           show={show}

--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -20,6 +20,7 @@ import Body from '../Story/Body';
 import CommentFooter from '../CommentFooter/CommentFooter';
 import HiddenCommentMessage from './HiddenCommentMessage';
 import './Comment.less';
+import MoreCommentsLink from './MoreCommentsLink';
 
 @injectIntl
 class Comment extends React.Component {
@@ -46,6 +47,7 @@ class Comment extends React.Component {
     onLikeClick: PropTypes.func,
     onDislikeClick: PropTypes.func,
     onSendComment: PropTypes.func,
+    renderAllChildren: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -56,11 +58,14 @@ class Comment extends React.Component {
     commentsChildren: undefined,
     pendingVotes: [],
     depth: 0,
+    renderAllChildren: false,
     notify: () => {},
     onLikeClick: () => {},
     onDislikeClick: () => {},
     onSendComment: () => {},
   };
+
+  static SHOW_COMMENTS_INCREMENT = 20;
 
   constructor(props) {
     super(props);
@@ -71,9 +76,11 @@ class Comment extends React.Component {
       showCommentFormLoading: false,
       commentFormText: '',
       showHiddenComment: false,
+      nRenderedComments: props.renderAllChildren ? Infinity : Math.floor(3 / (props.depth + 1)),
     };
 
     this.handleSubmitComment = this.handleSubmitComment.bind(this);
+    this.handleShowMoreComments = this.handleShowMoreComments.bind(this);
   }
 
   componentDidMount() {
@@ -202,6 +209,12 @@ class Comment extends React.Component {
     });
   };
 
+  handleShowMoreComments() {
+    this.setState(prevState => ({
+      nRenderedComments: prevState.nRenderedComments + Comment.SHOW_COMMENTS_INCREMENT,
+    }));
+  }
+
   render() {
     const {
       user,
@@ -218,7 +231,7 @@ class Comment extends React.Component {
       defaultVotePercent,
       rewriteLinks,
     } = this.props;
-    const { showHiddenComment } = this.state;
+    const { showHiddenComment, nRenderedComments } = this.state;
     const anchorId = `@${comment.author}/${comment.permlink}`;
     const anchorLink = `${comment.url.slice(0, comment.url.indexOf('#'))}#${anchorId}`;
 
@@ -348,27 +361,39 @@ class Comment extends React.Component {
             {!this.state.collapsed &&
               commentsChildren &&
               commentsChildren[comment.id] &&
-              sortComments(commentsChildren[comment.id], sort).map(child => (
-                <Comment
-                  key={child.id}
-                  user={user}
-                  depth={depth + 1}
-                  intl={this.props.intl}
-                  comment={child}
-                  parent={comment}
-                  pendingVotes={pendingVotes}
-                  rootPostAuthor={rootPostAuthor}
-                  commentsChildren={commentsChildren}
-                  notify={this.props.notify}
-                  rewardFund={rewardFund}
-                  sliderMode={sliderMode}
-                  defaultVotePercent={defaultVotePercent}
-                  rewriteLinks={rewriteLinks}
-                  onLikeClick={this.props.onLikeClick}
-                  onDislikeClick={this.props.onDislikeClick}
-                  onSendComment={this.props.onSendComment}
+              sortComments(commentsChildren[comment.id], sort)
+                .slice(0, nRenderedComments)
+                .map(child => (
+                  <Comment
+                    key={child.id}
+                    user={user}
+                    depth={depth + 1}
+                    intl={this.props.intl}
+                    comment={child}
+                    parent={comment}
+                    pendingVotes={pendingVotes}
+                    rootPostAuthor={rootPostAuthor}
+                    commentsChildren={commentsChildren}
+                    notify={this.props.notify}
+                    rewardFund={rewardFund}
+                    sliderMode={sliderMode}
+                    defaultVotePercent={defaultVotePercent}
+                    rewriteLinks={rewriteLinks}
+                    onLikeClick={this.props.onLikeClick}
+                    onDislikeClick={this.props.onDislikeClick}
+                    onSendComment={this.props.onSendComment}
+                    renderAllChildren={this.props.renderAllChildren}
+                  />
+                ))}
+            {!this.state.collapsed &&
+              commentsChildren &&
+              commentsChildren[comment.id] && (
+                <MoreCommentsLink
+                  comments={commentsChildren[comment.id].length}
+                  visibleComments={nRenderedComments}
+                  onClick={this.handleShowMoreComments}
                 />
-              ))}
+              )}
           </div>
         </div>
       </div>

--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -9,6 +9,8 @@ import SortSelector from '../SortSelector/SortSelector';
 import CommentForm from './CommentForm';
 import Comment from './Comment';
 import './Comments.less';
+import MoreCommentsLink from './MoreCommentsLink';
+import { findRootComment, getLinkedComment } from '../../helpers/commentHelpers';
 
 @injectIntl
 class Comments extends React.Component {
@@ -18,7 +20,8 @@ class Comments extends React.Component {
     authenticated: PropTypes.bool.isRequired,
     username: PropTypes.string,
     parentPost: PropTypes.shape(),
-    comments: PropTypes.arrayOf(PropTypes.shape()),
+    comments: PropTypes.shape(),
+    rootLevelComments: PropTypes.arrayOf(PropTypes.shape()),
     commentsChildren: PropTypes.shape(),
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
@@ -41,7 +44,8 @@ class Comments extends React.Component {
   static defaultProps = {
     username: undefined,
     parentPost: undefined,
-    comments: [],
+    comments: {},
+    rootLevelComments: [],
     commentsChildren: undefined,
     pendingVotes: [],
     rewriteLinks: false,
@@ -54,6 +58,8 @@ class Comments extends React.Component {
     onSendComment: () => {},
   };
 
+  static SHOW_COMMENTS_INCREMENT = 20;
+
   constructor(props) {
     super(props);
 
@@ -62,12 +68,14 @@ class Comments extends React.Component {
       showCommentFormLoading: false,
       commentFormText: '',
       commentSubmitted: false,
+      nRenderedComments: 20,
     };
 
     this.detectSort = this.detectSort.bind(this);
     this.setSort = this.setSort.bind(this);
     this.handleSortChange = this.handleSortChange.bind(this);
     this.handleSubmitComment = this.handleSubmitComment.bind(this);
+    this.handleShowMoreComments = this.handleShowMoreComments.bind(this);
   }
 
   componentDidMount() {
@@ -95,6 +103,12 @@ class Comments extends React.Component {
 
   handleSortChange(type) {
     this.setSort(type);
+  }
+
+  handleShowMoreComments() {
+    this.setState(prevState => ({
+      nRenderedComments: prevState.nRenderedComments + Comments.SHOW_COMMENTS_INCREMENT,
+    }));
   }
 
   handleImageInserted = (blob, callback, errorCallback) => {
@@ -156,13 +170,28 @@ class Comments extends React.Component {
       });
   }
 
+  commentsToRender(rootLevelComments, rootLinkedComment) {
+    const { nRenderedComments, sort } = this.state;
+
+    const filteredComments = sortComments(rootLevelComments, sort)
+      .filter(comment => comment.id !== (rootLinkedComment && rootLinkedComment.id))
+      .slice(
+        0,
+        rootLinkedComment
+          ? nRenderedComments - Comments.SHOW_COMMENTS_INCREMENT
+          : nRenderedComments,
+      );
+    return rootLinkedComment ? [rootLinkedComment, ...filteredComments] : filteredComments;
+  }
+
   render() {
     const {
       user,
       comments,
+      rootLevelComments,
+      commentsChildren,
       loading,
       show,
-      commentsChildren,
       pendingVotes,
       onLikeClick,
       onDislikeClick,
@@ -174,6 +203,9 @@ class Comments extends React.Component {
       rewriteLinks,
     } = this.props;
     const { sort } = this.state;
+
+    const rootLinkedComment = findRootComment(comments, getLinkedComment(comments));
+    const commentsToRender = this.commentsToRender(rootLevelComments, rootLinkedComment);
 
     return (
       <div className="Comments">
@@ -214,7 +246,7 @@ class Comments extends React.Component {
         {!loading &&
           show &&
           comments &&
-          sortComments(comments, sort).map(comment => (
+          commentsToRender.map(comment => (
             <Comment
               key={comment.id}
               user={user}
@@ -235,8 +267,14 @@ class Comments extends React.Component {
               onLikeClick={onLikeClick}
               onDislikeClick={onDislikeClick}
               onSendComment={this.props.onSendComment}
+              renderAllChildren={rootLinkedComment && comment.id === rootLinkedComment.id}
             />
           ))}
+        <MoreCommentsLink
+          comments={rootLevelComments.length}
+          visibleComments={commentsToRender.length}
+          onClick={this.handleShowMoreComments}
+        />
       </div>
     );
   }

--- a/src/client/components/Comments/MoreCommentsLink.js
+++ b/src/client/components/Comments/MoreCommentsLink.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MoreCommentsLink = ({ comments, visibleComments, onClick }) => {
+  if (comments === 0 || visibleComments >= comments) {
+    return null;
+  }
+  return (
+    <div role="button" tabIndex="-1" onClick={onClick}>
+      <a>show more comments ({comments - visibleComments})</a>
+    </div>
+  );
+};
+
+MoreCommentsLink.propTypes = {
+  comments: PropTypes.number.isRequired,
+  visibleComments: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default MoreCommentsLink;

--- a/src/client/components/Reactions/ReactionsModal.js
+++ b/src/client/components/Reactions/ReactionsModal.js
@@ -27,6 +27,9 @@ class ReactionsModal extends React.Component {
   };
 
   render() {
+    if (!this.props.visible) {
+      return null;
+    }
     const { upVotes, downVotes, ratio } = this.props;
 
     const tabs = [];

--- a/src/client/helpers/commentHelpers.js
+++ b/src/client/helpers/commentHelpers.js
@@ -1,0 +1,52 @@
+/**
+ * Finds the currently linked comment in the url after the anchor #
+ * @param comments a array|object of comment objects
+ * @returns the comment linked or null if not found
+ */
+export function getLinkedComment(comments = []) {
+  const anchor = window.location.hash.replace('#', '');
+  if (Array.isArray(comments)) {
+    for (let i = 0; i < comments.length; i += 1) {
+      const commentAnchor = comments[i].url.split('#')[1];
+      if (commentAnchor === anchor) {
+        return comments[i];
+      }
+    }
+  } else {
+    const commentsKeys = Object.keys(comments);
+    for (let i = 0; i < commentsKeys.length; i += 1) {
+      const comment = comments[commentsKeys[i]];
+      const commentAnchor = comment.url.split('#')[1];
+      if (commentAnchor === anchor) {
+        return comment;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Finds the root comment from a give child comment.
+ * Root refers to level 1 comments not the post related to the comments.
+ * @param comments An object of id:comment objects
+ * @param child The comment to start the traversal from
+ * @returns {*}
+ */
+export function findRootComment(comments, child) {
+  if (!child) {
+    return null;
+  }
+  let root = child;
+  const commentIDS = Object.keys(comments);
+  while (root && root.depth > 1) {
+    for (let i = 0; i < commentIDS.length; i += 1) {
+      if (comments[commentIDS[i]].permlink === root.parent_permlink) {
+        root = comments[commentIDS[i]];
+        break;
+      }
+    }
+  }
+  return root;
+}
+
+export default null;


### PR DESCRIPTION
Fixes #1413 

Changes:
- Add component for show more comments `MoreCommentsLink`
- Creates comment helpers for finding nodes

I wanted to get some feedback to see if this is on the right path. I noticed that the biggest lag issue is that each comment takes awhile to load. Even just rendering 20 comments takes almost 1 second. This seems too long. 

Here's a graph of rendering 20 top level comments (not children). The `Buttons` for each comment take anywhere from 15ms up to 70ms each to render. I don't have much experience with performance issues so I'm not sure.

![busy_comments_flame](https://user-images.githubusercontent.com/3497205/37133634-77dd8426-2249-11e8-80bf-e3197b7f4c1d.PNG)

