### PR TITLE
Usability with slow internet

### DIFF
--- a/src/client/steemAPI.js
+++ b/src/client/steemAPI.js
@@ -1,6 +1,12 @@
 import { createClient } from 'lightrpc';
 
-const client = createClient(process.env.STEEMJS_URL || 'https://api.steemit.com');
+const options = {
+  timeout: 15000,
+};
+
+const steemUrl = process.env.STEEMJS_URL || 'https://api.steemit.com';
+
+const client = createClient(steemUrl, options);
 client.sendAsync = (message, params) =>
   new Promise((resolve, reject) => {
     client.send(message, params, (err, result) => {


### PR DESCRIPTION
I'm having an issue that sounds similar to #1576.

Unfortunately my internet is slow right now.

This has led to find that both Busy client and server have a maximum timeout of 5 seconds. 

![screenshot from 2018-03-08 19-05-17](https://user-images.githubusercontent.com/9503662/37183585-cf8272de-2304-11e8-9a8d-b456e9c64a16.png)

[Related issue for rpc.](https://github.com/busyorg/lightrpc/issues/6)