### PR TITLE
fix: handle timeout on AMP

### DIFF
--- a/src/server/handlers/createAmpHandler.js
+++ b/src/server/handlers/createAmpHandler.js
@@ -6,20 +6,26 @@ const debug = require('debug')('busy:server');
 
 export default function createAmpHandler(template) {
   return function ampResponse(req, res) {
-    steemAPI.sendAsync('get_content', [req.params.author, req.params.permlink]).then(result => {
-      if (result.id === 0) return res.sendStatus(404);
-      const appUrl = url.format({
-        protocol: req.protocol,
-        host: req.get('host'),
-      });
+    steemAPI
+      .sendAsync('get_content', [req.params.author, req.params.permlink])
+      .then(result => {
+        if (result.id === 0) return res.sendStatus(404);
+        const appUrl = url.format({
+          protocol: req.protocol,
+          host: req.get('host'),
+        });
 
-      try {
-        const page = renderAmpPage(result, appUrl, template);
-        return res.send(page);
-      } catch (error) {
-        debug('Error while parsing AMP response', error);
+        try {
+          const page = renderAmpPage(result, appUrl, template);
+          return res.send(page);
+        } catch (error) {
+          debug('Error while parsing AMP response', error);
+          return res.status(500).send('500 Internal Server Error');
+        }
+      })
+      .catch(err => {
+        debug('AMP: Steem API request timed out.', err);
         return res.status(500).send('500 Internal Server Error');
-      }
-    });
+      });
   };
 }


### PR DESCRIPTION
Sometimes Steem API would take a long time to respond, which caused timeouts.
They weren't properly handled when rendering AMP.