### PR TITLE
Update Busy link regex

### DIFF
--- a/src/client/vendor/SanitizeConfig.js
+++ b/src/client/vendor/SanitizeConfig.js
@@ -156,7 +156,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [] }) => ({
       if (!href) href = '#';
       href = href.trim();
       const attys = { href };
-      if (!href.match(/^https:\/\/(staging\.)?busy\.org(?![\w\.]+)/)) {
+      if (!href.match(/^^(\/|https:\/\/(staging\.)?busy\.org(?![\w\.]+))/)) {
         attys.target = '_blank'; // pending iframe impl https://mathiasbynens.github.io/rel-noopener/
         attys.rel = 'nofollow noopener';
       }

--- a/src/client/vendor/SanitizeConfig.js
+++ b/src/client/vendor/SanitizeConfig.js
@@ -156,8 +156,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [] }) => ({
       if (!href) href = '#';
       href = href.trim();
       const attys = { href };
-      // If it's not a (relative or absolute) steemit URL...
-      if (!href.match(/^(\/(?!\/)|https:\/\/(app\.|dev\.)?busy.org)/)) {
+      if (!href.match(/^https:\/\/(staging\.)?busy\.org(?![\w\.]+)/)) {
         attys.target = '_blank'; // pending iframe impl https://mathiasbynens.github.io/rel-noopener/
         attys.rel = 'nofollow noopener';
       }


### PR DESCRIPTION
Fixes #1629 

Changes:
- Update regex, so it doesn't match URLs in the format: `https://busy.org.something.else.com`
