### PR TITLE
Remove black gaps on mobile layout (User Cover Image)

### DIFF
--- a/src/client/components/UserHeader.less
+++ b/src/client/components/UserHeader.less
@@ -3,7 +3,7 @@
 
 .UserHeader {
   background-color: #f3f4f6;
-  background-size: cover;
+  background-size: auto;
   background-position: center;
   position: relative;
 

--- a/src/client/components/UserHeader.less
+++ b/src/client/components/UserHeader.less
@@ -22,7 +22,7 @@
 
   &--cover {
     background-color: darken(@primary-color, 25%) !important;
-
+    background-size: auto;
     .UserHeader__rank,
     .UserHeader__rank & > i,
     .UserHeader__handle,


### PR DESCRIPTION
This is a simple fix on the black cover image gaps on mobile layout.

From:
![https://i.imgur.com/0o6Rt76.png](https://i.imgur.com/0o6Rt76.png)

To:

![https://i.imgur.com/VvDj30x.png](https://i.imgur.com/VvDj30x.png)
