### PR TITLE
feat: migrate to busy-ipfs

### DIFF
--- a/src/client/components/Editor/withEditor.js
+++ b/src/client/components/Editor/withEditor.js
@@ -24,19 +24,19 @@ export default function withEditor(WrappedComponent) {
     };
 
     handleImageUpload = (blob, callback, errorCallback) => {
-      const { intl: { formatMessage }, user } = this.props;
+      const { intl: { formatMessage } } = this.props;
       message.info(
         formatMessage({ id: 'notify_uploading_image', defaultMessage: 'Uploading image' }),
       );
       const formData = new FormData();
-      formData.append('files', blob);
+      formData.append('file', blob);
 
-      fetch(`https://img.busy.org/@${user.name}/uploads`, {
+      fetch(`https://ipfs.busy.org/upload`, {
         method: 'POST',
         body: formData,
       })
         .then(res => res.json())
-        .then(res => callback(res.secure_url, blob.name))
+        .then(res => callback(res.url, blob.name))
         .catch(err => {
           console.log('err', err);
           errorCallback();

--- a/src/client/helpers/image.js
+++ b/src/client/helpers/image.js
@@ -4,7 +4,7 @@ const IMG_PROXY = 'https://steemitimages.com/0x0/';
 const IMG_PROXY_PREVIEW = 'https://steemitimages.com/600x800/';
 const IMG_PROXY_SMALL = 'https://steemitimages.com/40x40/';
 
-export const MAXIMUM_UPLOAD_SIZE = 52428800;
+export const MAXIMUM_UPLOAD_SIZE = 15728640;
 export const MAXIMUM_UPLOAD_SIZE_HUMAN = filesize(MAXIMUM_UPLOAD_SIZE);
 
 export const getProxyImageURL = (url, type) => {

--- a/src/client/helpers/image.js
+++ b/src/client/helpers/image.js
@@ -8,7 +8,9 @@ export const MAXIMUM_UPLOAD_SIZE = 15728640;
 export const MAXIMUM_UPLOAD_SIZE_HUMAN = filesize(MAXIMUM_UPLOAD_SIZE);
 
 export const getProxyImageURL = (url, type) => {
-  if (type === 'preview') {
+  if (url.indexOf('https://ipfs.busy.org') === 0) {
+    return url;
+  } else if (type === 'preview') {
     return `${IMG_PROXY_PREVIEW}${url}`;
   } else if (type === 'small') {
     return `${IMG_PROXY_SMALL}${url}`;


### PR DESCRIPTION
Fixes #1568

Changes:
- Upload images to busy-ipfs instead of Cloudinary.

Busy IPFS source code is there at the moment:
https://github.com/Sekhmet/busy-ipfs