### PR TITLE
Fix for mobile search causing blank screen

### DIFF
--- a/src/client/components/Navigation/Topnav.js
+++ b/src/client/components/Navigation/Topnav.js
@@ -272,7 +272,7 @@ class Topnav extends React.Component {
   handleMobileSearchButtonClick = () => {
     const { searchBarActive } = this.state;
     this.setState({ searchBarActive: !searchBarActive }, () => {
-      this.searchInputRef.refs.input.focus();
+      this.searchInputRef.input.focus();
     });
   };
 


### PR DESCRIPTION
Fixes:
- go to staging.busy.org on mobile / small screen, and click on search
- search errors out and causes entire page to be blank

Changes:
- update searchInputRef to use the right input due to antd upgrade