### PR TITLE
fix: prevent replacement patterns

### DIFF
--- a/src/server/renderers/ssrRenderer.js
+++ b/src/server/renderers/ssrRenderer.js
@@ -12,7 +12,7 @@ export default function renderSsrPage(store, html, template, noindex) {
     .replace('<!--server:html-->', html)
     .replace(
       '<!--server:scripts-->',
-      `<script>
+      () => `<script>
         // WARNING: See the following for security issues around embedding JSON in HTML:
         // http://redux.js.org/docs/recipes/ServerRendering.html#security-considerations
         window.__PRELOADED_STATE__ = ${JSON.stringify(preloadedState)


### PR DESCRIPTION
Fixes #1687 

Changes:
- This prevents `replace` to interpolate string (see the issue for more).

https://busy.org/@hernandev/project-total-rewards-api-for-utopian-rewards-badges
vs
https://busy-master-pr-1688.herokuapp.com/@hernandev/project-total-rewards-api-for-utopian-rewards-badges