### PR TITLE
Change whitelisted applications to Steemscript instead of internal list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "secure-random": "^1.1.1",
     "socket.io": "^1.4.5",
     "speakingurl": "^11.0.0",
+    "steemscript": "https://github.com/busyorg/steemscript.git",
     "store": "^1.3.20",
     "striptags": "^2.1.1",
     "style-loader": "^0.19.0",

--- a/src/client/helpers/apps.js
+++ b/src/client/helpers/apps.js
@@ -1,18 +1,13 @@
-export default {
-  steemit: 'Steemit',
-  busy: 'Busy',
-  esteem: 'eSteem',
-  chainbb: 'chainBB',
-  utopian: 'Utopian',
-  dtube: 'DTube',
-  dlive: 'DLive',
-  dmania: 'dMania',
-  dsound: 'DSound',
-  steepshot: 'Steepshot',
-  zappl: 'Zappl',
-  steemkr: 'Steemkr',
-  steemhunt: 'Steemhunt',
-  steemjs: 'Steem.js',
-  steemplace: 'Steem.Place',
-  strimi: 'Strimi',
-};
+// get full application list from scripts json.
+const appsList = require('steemscript/apps.json')
+
+// start an empty object for the applications names.
+const apps = {}
+
+// "map" each one extracting the name key
+Object.keys(appsList).forEach((key) => {
+  apps[key] = appsList[key].name
+});
+
+// export the result.
+export default apps

--- a/yarn.lock
+++ b/yarn.lock
@@ -8446,6 +8446,10 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+"steemscript@https://github.com/busyorg/steemscript.git":
+  version "0.0.1"
+  resolved "https://github.com/busyorg/steemscript.git#0a2ffcba66e9ebb093a0e511e78ffa22b7b9023d"
+
 store@^1.3.20:
   version "1.3.20"
   resolved "https://registry.yarnpkg.com/store/-/store-1.3.20.tgz#13ea7e3fb2d6c239868265d686b1d84e99c5be3e"


### PR DESCRIPTION
Changes:
- Added https://github.com/busyorg/steemscript as a dependency.

This dependency was added directly from GIT because the NPM release is 2 years old.

- Replaced `client/helpers/apps.js`

Instead of an internal list, use the one on the previous topic to build the user-friend application names.
