### PR TITLE
Use image alt attribute as lightbox title

### DIFF
--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -85,6 +85,7 @@ class StoryFull extends React.Component {
     this.state = {
       lightbox: {
         open: false,
+        title: '',
         index: 0,
       },
     };
@@ -140,6 +141,7 @@ class StoryFull extends React.Component {
           this.setState({
             lightbox: {
               open: true,
+              title: e.target.getAttribute('alt'),
               index: i,
             },
           });
@@ -201,7 +203,7 @@ class StoryFull extends React.Component {
     } = this.props;
     const { isReported } = postState;
 
-    const { open, index } = this.state.lightbox;
+    const { open, index, title } = this.state.lightbox;
 
     let signedBody = post.body;
     if (signature) {
@@ -437,6 +439,7 @@ class StoryFull extends React.Component {
         <div className="StoryFull__content">{content}</div>
         {open && (
           <Lightbox
+            imageTitle={title}
             mainSrc={this.images[index]}
             nextSrc={this.images[(index + 1) % this.images.length]}
             prevSrc={this.images[(index + (this.images.length - 1)) % this.images.length]}

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -16,7 +16,7 @@ import { Tag, Icon, Popover, Tooltip } from 'antd';
 import Lightbox from 'react-image-lightbox';
 import { Scrollbars } from 'react-custom-scrollbars';
 import formatter from '../../helpers/steemitFormatter';
-import { getFromMetadata, extractImages } from '../../helpers/parser';
+import { getFromMetadata, extractImageTags } from '../../helpers/parser';
 import { isPostDeleted, dropCategory } from '../../helpers/postHelpers';
 import withAuthActions from '../../auth/withAuthActions';
 import { getProxyImageURL } from '../../helpers/image';
@@ -85,12 +85,12 @@ class StoryFull extends React.Component {
     this.state = {
       lightbox: {
         open: false,
-        title: '',
         index: 0,
       },
     };
 
     this.images = [];
+    this.imagesAlts = [];
 
     this.handleClick = this.handleClick.bind(this);
     this.handleContentClick = this.handleContentClick.bind(this);
@@ -141,7 +141,6 @@ class StoryFull extends React.Component {
           this.setState({
             lightbox: {
               open: true,
-              title: e.target.getAttribute('alt'),
               index: i,
             },
           });
@@ -203,7 +202,7 @@ class StoryFull extends React.Component {
     } = this.props;
     const { isReported } = postState;
 
-    const { open, index, title } = this.state.lightbox;
+    const { open, index } = this.state.lightbox;
 
     let signedBody = post.body;
     if (signature) {
@@ -212,7 +211,7 @@ class StoryFull extends React.Component {
 
     const parsedBody = getHtml(signedBody, {}, 'text');
 
-    this.images = extractImages(parsedBody);
+    this.images = extractImageTags(parsedBody);
 
     const tags = _.union(getFromMetadata(post.json_metadata, 'tags'), [post.category]);
 
@@ -439,10 +438,10 @@ class StoryFull extends React.Component {
         <div className="StoryFull__content">{content}</div>
         {open && (
           <Lightbox
-            imageTitle={title}
-            mainSrc={this.images[index]}
-            nextSrc={this.images[(index + 1) % this.images.length]}
-            prevSrc={this.images[(index + (this.images.length - 1)) % this.images.length]}
+            imageTitle={this.images[index].alt}
+            mainSrc={this.images[index].src}
+            nextSrc={this.images[(index + 1) % this.images.length].src}
+            prevSrc={this.images[(index + (this.images.length - 1)) % this.images.length].src}
             onCloseRequest={() => {
               this.setState({
                 lightbox: {

--- a/src/client/helpers/parser.js
+++ b/src/client/helpers/parser.js
@@ -7,7 +7,8 @@ export function getFromMetadata(jsonMetadata, key) {
   return _.get(metadata, key);
 }
 
-const imgRegex = /<img[^>]+src="([^">]+)"/g;
+const attr = /(\w+)="(.*?)"/;
+const imgTag = /<img(.*)\/>/g;
 const hrefRegex = /<a[^>]+href="([^">]+)"/g;
 
 function extract(body, regex) {
@@ -22,8 +23,20 @@ function extract(body, regex) {
   return matches;
 }
 
-export function extractImages(body) {
-  return extract(body, imgRegex);
+export function extractImageTags(body) {
+  const imageTags = extract(body, imgTag);
+
+  return imageTags.map(image => {
+    const pairs = image.trim().split(' ');
+
+    return pairs.reduce((a, b) => {
+      const matches = b.match(attr);
+      return {
+        ...a,
+        [matches[1]]: matches[2],
+      };
+    }, {});
+  });
 }
 
 export function extractLinks(body) {

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -11,7 +11,7 @@ import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
 import { getHtml } from '../../components/Story/Body';
 import improve from '../../helpers/improve';
-import { extractImages, extractLinks } from '../../helpers/parser';
+import { extractImageTags, extractLinks } from '../../helpers/parser';
 import { rewardsValues } from '../../../common/constants/rewards';
 import DeleteDraftModal from './DeleteDraftModal';
 
@@ -184,7 +184,7 @@ class Write extends React.Component {
 
     const parsedBody = getHtml(postBody, {}, 'text');
 
-    const images = extractImages(parsedBody);
+    const images = extractImageTags.map(tag => tag.src);
     const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {


### PR DESCRIPTION
Fixes #942 

### Changes
- [x] Use alt tags to display image title in the lightbox.
- [x] Add `extractImageTags` parser method.

### Test plan
- [x] Go to post with images: https://busy-master-pr-1728.herokuapp.com/@vaansteam/top-8-best-tips-for-drawing-animals
- [x] Click on some image.
- [x] Image alt title should be shown.
- [x] Alt title should change when using next and previous buttons.
