### PR TITLE
Disable autosize from EditorInput

### DIFF
--- a/src/client/components/Comments/CommentForm.js
+++ b/src/client/components/Comments/CommentForm.js
@@ -111,8 +111,8 @@ class CommentForm extends React.Component {
         <div className="CommentForm__text">
           <Element name="commentFormInputScrollerElement">
             <EditorInput
+              rows={3}
               inputRef={this.setInput}
-              autosize={{ minRows: 3, maxRows: 6 }}
               value={body}
               onChange={this.handleBodyUpdate}
               onImageUpload={this.props.onImageUpload}

--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -301,7 +301,7 @@ class Editor extends React.Component {
             ],
           })(
             <EditorInput
-              autosize={{ minRows: 6, maxRows: 30 }}
+              rows={12}
               addon={
                 <FormattedMessage
                   id="reading_time"

--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -301,7 +301,7 @@ class Editor extends React.Component {
             ],
           })(
             <EditorInput
-              autosize={{ minRows: 6, maxRows: 12 }}
+              autosize={{ minRows: 6, maxRows: 30 }}
               addon={
                 <FormattedMessage
                   id="reading_time"

--- a/src/client/components/Editor/EditorInput.js
+++ b/src/client/components/Editor/EditorInput.js
@@ -15,13 +15,6 @@ class EditorInput extends React.Component {
     inputId: PropTypes.string,
     addon: PropTypes.node,
     inputRef: PropTypes.func,
-    autosize: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.shape({
-        minRows: PropTypes.number,
-        maxRows: PropTypes.number,
-      }),
-    ]),
     onChange: PropTypes.func,
     onImageUpload: PropTypes.func,
     onImageInvalid: PropTypes.func,
@@ -29,7 +22,6 @@ class EditorInput extends React.Component {
 
   static defaultProps = {
     addon: null,
-    autosize: false,
     inputId: '',
     inputRef: () => {},
     onChange: () => {},
@@ -296,7 +288,7 @@ class EditorInput extends React.Component {
   }
 
   render() {
-    const { addon, autosize, value } = this.props;
+    const { addon, value, ...restProps } = this.props;
     const { dropzoneActive } = this.state;
 
     return (
@@ -323,7 +315,7 @@ class EditorInput extends React.Component {
             )}
             <HotKeys keyMap={this.constructor.hotkeys} handlers={this.handlers}>
               <Input.TextArea
-                autosize={autosize}
+                {...restProps}
                 onChange={this.handleChange}
                 value={value}
                 ref={this.setInput}

--- a/src/client/settings/ProfileSettings.js
+++ b/src/client/settings/ProfileSettings.js
@@ -284,7 +284,7 @@ export default class ProfileSettings extends React.Component {
                       initialValue: '',
                     })(
                       <EditorInput
-                        autosize={{ minRows: 3, maxRows: 6 }}
+                        rows={6}
                         onChange={this.handleSignatureChange}
                         onImageUpload={this.props.onImageUpload}
                         onImageInvalid={this.props.onImageInvalid}


### PR DESCRIPTION
Fixes #1500 

### Changes
- [x] EditorInput doesn't scale automatically.
- [x] It can be scaled in any way user wants.

### Test plan
- [x] Go to editor: https://busy-master-pr-1730.herokuapp.com/editor
- [x] Type something longer than 12 rows.
- [x] TextInput shouldn't scale.
- [x] Dragging EditorInput should resize input (its height).

### Screenshot

![image](https://user-images.githubusercontent.com/1968722/38759482-697cd02c-3f76-11e8-9a73-32599a0dc87b.png)
