### PR TITLE
fix: use proper translation keys for vote actions

### DIFF
--- a/src/client/activity/VoteActionMessage.js
+++ b/src/client/activity/VoteActionMessage.js
@@ -30,7 +30,7 @@ const VoteActionMessage = ({ actionDetails, currentUsername }) => {
         </span>
       ) : (
         <FormattedMessage
-          id={`user_${voteType}_post`}
+          id={`user_${voteType}`}
           defaultMessage={`{username} ${voteType}`}
           values={{
             username: (


### PR DESCRIPTION
Fixes #1187

Translation keys don't have `_post` suffix.

### Changes
- Remove `_post` suffix.
