### PR TITLE
Add handling small resolutions for user menu

### DIFF
--- a/src/client/components/PopoverMenu/PopoverMenu.less
+++ b/src/client/components/PopoverMenu/PopoverMenu.less
@@ -1,6 +1,6 @@
 .PopoverMenu {
   max-height: 55vh;
-  overflow: scroll;
+  overflow-y: auto;
 
   & .iconfont,
   & .anticon {

--- a/src/client/components/PopoverMenu/PopoverMenu.less
+++ b/src/client/components/PopoverMenu/PopoverMenu.less
@@ -1,4 +1,7 @@
 .PopoverMenu {
+  max-height: 55vh;
+  overflow: scroll;
+
   & .iconfont,
   & .anticon {
     vertical-align: -2px;


### PR DESCRIPTION
Fixes: #1193 

When user menu is launched on small res device it does not take whole screen and it's scrollable, as @Sekhmet described.

### Summary of Changes
* added css rules

### Screenshots/Videos 
![suprmenu](https://user-images.githubusercontent.com/8305170/38772723-eb9aeaa4-403d-11e8-8761-933eb92313b1.gif)


