### PR TITLE
Use lodash get in parser.js to fix post breaking

### DIFF
--- a/src/client/helpers/parser.js
+++ b/src/client/helpers/parser.js
@@ -31,9 +31,11 @@ export function extractImageTags(body) {
 
     return pairs.reduce((a, b) => {
       const matches = b.match(attr);
+      const key = _.get(matches, 1);
+      const value = _.get(matches, 2);
       return {
         ...a,
-        [matches[1]]: matches[2],
+        [key]: value,
       };
     }, {});
   });

--- a/src/client/helpers/parser.js
+++ b/src/client/helpers/parser.js
@@ -7,7 +7,8 @@ export function getFromMetadata(jsonMetadata, key) {
   return _.get(metadata, key);
 }
 
-const attr = /(\w+)="(.*?)"/;
+const attrs = /(\w+=".*?")/g;
+const attrElements = /^(\w+)="(.*?)"$/;
 const imgTag = /<img(.*)\/>/g;
 const hrefRegex = /<a[^>]+href="([^">]+)"/g;
 
@@ -24,19 +25,22 @@ function extract(body, regex) {
 }
 
 export function extractImageTags(body) {
-  const imageTags = extract(body, imgTag);
+  return extract(body, imgTag).map(image => {
+    const attributes = image.match(attrs);
 
-  return imageTags.map(image => {
-    const pairs = image.trim().split(' ');
+    return attributes.reduce((a, b) => {
+      const values = b.match(attrElements);
 
-    return pairs.reduce((a, b) => {
-      const matches = b.match(attr);
-      const key = _.get(matches, 1);
-      const value = _.get(matches, 2);
-      return {
-        ...a,
-        [key]: value,
-      };
+      if (_.size(values) === 3) {
+        const key = _.get(values, 1);
+        const value = _.get(values, 2);
+        return {
+          ...a,
+          [key]: value,
+        };
+      }
+
+      return a;
     }, {});
   });
 }

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { replace } from 'react-router-redux';
-import kebabCase from 'lodash/kebabCase';
-import debounce from 'lodash/debounce';
-import isArray from 'lodash/isArray';
+import _ from 'lodash';
 import 'url-search-params-polyfill';
 import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
@@ -97,7 +95,7 @@ class Write extends React.Component {
     const draftPost = draftPosts[draftId];
     if (draftPost) {
       let tags = [];
-      if (isArray(draftPost.jsonMetadata.tags)) {
+      if (_.isArray(draftPost.jsonMetadata.tags)) {
         tags = draftPost.jsonMetadata.tags;
       }
 
@@ -185,11 +183,11 @@ class Write extends React.Component {
 
     const parsedBody = getHtml(postBody, {}, 'text');
 
-    const images = extractImageTags.map(tag => tag.src);
+    const images = _.map(extractImageTags, tag => tag.src);
     const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {
-      data.permlink = kebabCase(data.title);
+      data.permlink = _.kebabCase(data.title);
     } else {
       data.permlink = this.permlink;
     }
@@ -236,7 +234,7 @@ class Write extends React.Component {
 
   handleCancelDeleteDraft = () => this.setState({ showModalDelete: false });
 
-  saveDraft = debounce(form => {
+  saveDraft = _.debounce(form => {
     if (this.props.saving) return;
 
     const data = this.getNewPostData(form);


### PR DESCRIPTION
Fixes #1758.

Changes:
- Use lodash _.get instead of directly calling the array property
