### PR TITLE
Overwrite json_metadata.app when the post edited via Busy. (#1706)

### DIFF
--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -204,8 +204,8 @@ class Write extends React.Component {
     // Busy (like video data from DTube)
     if (this.props.draftPosts[this.draftId] && this.props.draftPosts[this.draftId].jsonMetadata) {
       metaData = {
-        ...metaData,
         ...this.props.draftPosts[this.draftId].jsonMetadata,
+        ...metaData,
       };
     }
 


### PR DESCRIPTION
Fixes #1706.

Busy.org doesn't hijack  ```json_metadata.app``` if a post edited via Busy. This changeset brings priority to busy's default json_metadata tags.

Note: Also, **community** and **format** fields in the json_metadata will have priority and overwritten if they're set before and edited via Busy later on.

