### PR TITLE
use open instead of close price for SBD

### DIFF
--- a/src/client/app/appReducer.js
+++ b/src/client/app/appReducer.js
@@ -4,6 +4,7 @@ import * as appTypes from './appActions';
 import * as authActions from '../auth/authActions';
 import * as postActions from '../post/postActions';
 import { getCryptoPriceIncreaseDetails } from '../helpers/cryptosHelper';
+import { SBD } from '../../common/constants/cryptos';
 
 const initialState = {
   isFetching: false,
@@ -98,7 +99,10 @@ export default (state = initialState, action) => {
       };
     case appTypes.GET_CRYPTO_PRICE_HISTORY.SUCCESS: {
       const { symbol, usdPriceHistory, btcPriceHistory } = action.payload;
-      const usdPriceHistoryByClose = _.map(usdPriceHistory.Data, data => data.close);
+      const usdPriceHistoryByClose = _.map(
+        usdPriceHistory.Data,
+        data => (symbol === SBD.symbol ? data.open : data.close),
+      );
       const btcPriceHistoryByClose = _.map(btcPriceHistory.Data, data => data.close);
       const priceDetails = getCryptoPriceIncreaseDetails(
         usdPriceHistoryByClose,


### PR DESCRIPTION
Fixes #1788

### Changes
Temporarily use open price instead of close since it is closer to the actual price for steem dollar
