### PR TITLE
fix: remove pointer cursor from comments h2

### DIFF
--- a/src/client/components/Story/StoryFull.less
+++ b/src/client/components/Story/StoryFull.less
@@ -43,7 +43,6 @@
     color: @primary-color;
     font-weight: 500;
     margin-top: 8px;
-    cursor: pointer;
   }
 
   &__topics {


### PR DESCRIPTION
### Changes

Summary of changes you made.

* Remove cursor pointer from comments h2.

### Test plan

Explain how to test changes you made.

* [x] Open post.
* [x] Hover on comments line below title.

### Demo
Before:
![hover_before](https://user-images.githubusercontent.com/1968722/39396244-f3cc9a08-4aea-11e8-930f-259c0e51fbb3.gif)

After:
![hover_after](https://user-images.githubusercontent.com/1968722/39396247-f7d5ff68-4aea-11e8-82bf-79292f919f4e.gif)

