### PR TITLE
feat: use 16:9 YouTube previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "css-loader": "^0.28.7",
     "debug": "~2.2.0",
     "diff-match-patch": "^1.0.0",
-    "embedjs": "^0.0.10",
+    "embedjs": "^0.0.11",
     "express": "^4.15.4",
     "extract-text-webpack-plugin": "^3.0.1",
     "file-loader": "^1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,9 +2705,9 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-embedjs@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/embedjs/-/embedjs-0.0.10.tgz#f595041ed4d627c189860aa33c1ce1f0f36333f6"
+embedjs@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/embedjs/-/embedjs-0.0.11.tgz#112794ca9b96cc4bd84846de34d4a6cb8a9915e0"
   dependencies:
     get-urls "^5.0.1"
 


### PR DESCRIPTION
Fixes #1749 

### Changes

* use embedjs 0.0.11

### Test plan

Explain how to test changes you made.

* [ ] Go to: @gtg
* [ ] YouTube thumbnails shouldn't have black bars.

### Demo

Before:
<img width="563" alt="zrzut ekranu 2018-05-02 o 16 05 20" src="https://user-images.githubusercontent.com/1968722/39527803-a6faf20c-4e22-11e8-8877-1de90fe9e254.png">

After:
<img width="555" alt="zrzut ekranu 2018-05-02 o 16 04 32" src="https://user-images.githubusercontent.com/1968722/39527755-8c937ff6-4e22-11e8-83e4-5d7356d16cec.png">
