### PR TITLE
fix: update Topics header margins

### DIFF
--- a/src/client/components/Navigation/Sidenav.js
+++ b/src/client/components/Navigation/Sidenav.js
@@ -8,44 +8,41 @@ const isNews = (match, location) => location.pathname.match(/trending/);
 const isWallet = (match, location) => location.pathname.match(/wallet/);
 const isReplies = (match, location) => location.pathname.match(/replies/);
 
-const Sidenav = ({ username }) => (
-  <div>
-    {username && (
-      <ul className="Sidenav">
-        <li>
-          <NavLink to={`/@${username}`}>
-            <i className="iconfont icon-mine" />
-            <FormattedMessage id="my_profile" defaultMessage="My profile" />
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to="/" activeClassName="Sidenav__item--active" exact>
-            <i className="iconfont icon-clock" />
-            <FormattedMessage id="feed" defaultMessage="Feed" />
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to="/trending" activeClassName="Sidenav__item--active" isActive={isNews}>
-            <i className="iconfont icon-headlines" />
-            <FormattedMessage id="news" defaultMessage="News" />
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to="/replies" activeClassName="Sidenav__item--active" isActive={isReplies}>
-            <i className="iconfont icon-message" />
-            <FormattedMessage id="replies" defaultMessage="Replies" />
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to="/wallet" activeClassName="Sidenav__item--active" isActive={isWallet}>
-            <i className="iconfont icon-wallet" />
-            <FormattedMessage id="wallet" defaultMessage="Wallet" />
-          </NavLink>
-        </li>
-      </ul>
-    )}
-  </div>
-);
+const Sidenav = ({ username }) =>
+  username ? (
+    <ul className="Sidenav">
+      <li>
+        <NavLink to={`/@${username}`}>
+          <i className="iconfont icon-mine" />
+          <FormattedMessage id="my_profile" defaultMessage="My profile" />
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to="/" activeClassName="Sidenav__item--active" exact>
+          <i className="iconfont icon-clock" />
+          <FormattedMessage id="feed" defaultMessage="Feed" />
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to="/trending" activeClassName="Sidenav__item--active" isActive={isNews}>
+          <i className="iconfont icon-headlines" />
+          <FormattedMessage id="news" defaultMessage="News" />
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to="/replies" activeClassName="Sidenav__item--active" isActive={isReplies}>
+          <i className="iconfont icon-message" />
+          <FormattedMessage id="replies" defaultMessage="Replies" />
+        </NavLink>
+      </li>
+      <li>
+        <NavLink to="/wallet" activeClassName="Sidenav__item--active" isActive={isWallet}>
+          <i className="iconfont icon-wallet" />
+          <FormattedMessage id="wallet" defaultMessage="Wallet" />
+        </NavLink>
+      </li>
+    </ul>
+  ) : null;
 
 Sidenav.propTypes = {
   username: PropTypes.string,

--- a/src/client/components/Sidebar/Topics.less
+++ b/src/client/components/Sidebar/Topics.less
@@ -5,8 +5,14 @@
   min-width: 150px;
   & > h4 {
     color: @text-color;
-    margin: 16px 0;
     font-weight: 500;
+    margin-bottom: 16px;
+  }
+
+  &:not(:first-child) {
+    & > h4 {
+      margin-top: 16px;
+    }
   }
 
   & > a {


### PR DESCRIPTION
Fixes #1837 

### Changes

Summary of changes you made.

* remove unnecessary margin from Topics header.
* remove empty `div` that was preventing `:first-child` selector from working.

### Demo

Before:
<img width="1138" alt="screen shot 2018-05-08 at 19 54 15" src="https://user-images.githubusercontent.com/1968722/39773891-9d105832-52f9-11e8-9378-6b8ada63bc52.png">

After:
<img width="1050" alt="screen shot 2018-05-08 at 19 56 09" src="https://user-images.githubusercontent.com/1968722/39773989-e25e8eea-52f9-11e8-9418-52c885874f42.png">

