### PR TITLE
Turn refresh icon into clickable button

### DIFF
--- a/src/client/components/Sidebar/InterestingPeople.js
+++ b/src/client/components/Sidebar/InterestingPeople.js
@@ -11,11 +11,9 @@ const InterestingPeople = ({ users, onRefresh }) => (
     <h4 className="SidebarContentBlock__title">
       <i className="iconfont icon-group SidebarContentBlock__icon" />{' '}
       <FormattedMessage id="interesting_people" defaultMessage="Interesting People" />
-      <i
-        role="presentation"
-        onClick={onRefresh}
-        className="iconfont icon-refresh InterestingPeople__icon-refresh"
-      />
+      <button onClick={onRefresh} className="InterestingPeople__button-refresh">
+        <i className="iconfont icon-refresh" />
+      </button>
     </h4>
     <div className="SidebarContentBlock__content">
       {users && users.map(user => <User key={user.name} user={user} />)}

--- a/src/client/components/Sidebar/InterestingPeople.less
+++ b/src/client/components/Sidebar/InterestingPeople.less
@@ -1,12 +1,14 @@
 @import (reference) '../../styles/custom.less';
 
-.InterestingPeople__icon-refresh {
-  font-size: 22px !important;
+.InterestingPeople__button-refresh {
   margin-left: auto;
   cursor: pointer;
+  background: none;
+  border: none;
+  outline: none;
 }
 
-div[data-dir='rtl'] .InterestingPeople__icon-refresh {
+div[data-dir='rtl'] .InterestingPeople__button-refresh {
   margin-left: 0;
   margin-right: auto;
 }

--- a/src/client/components/Sidebar/__tests__/__snapshots__/InterestingPeople.js.snap
+++ b/src/client/components/Sidebar/__tests__/__snapshots__/InterestingPeople.js.snap
@@ -48,11 +48,14 @@ ShallowWrapper {
             id="interesting_people"
             values={Object {}}
           />
-          <i
-            className="iconfont icon-refresh InterestingPeople__icon-refresh"
+          <button
+            className="InterestingPeople__button-refresh"
             onClick={[Function]}
-            role="presentation"
-          />
+          >
+            <i
+              className="iconfont icon-refresh"
+            />
+          </button>
         </h4>,
         <div
           className="SidebarContentBlock__content"
@@ -120,11 +123,14 @@ ShallowWrapper {
               id="interesting_people"
               values={Object {}}
             />,
-            <i
-              className="iconfont icon-refresh InterestingPeople__icon-refresh"
+            <button
+              className="InterestingPeople__button-refresh"
               onClick={[Function]}
-              role="presentation"
-            />,
+            >
+              <i
+                className="iconfont icon-refresh"
+              />
+            </button>,
           ],
           "className": "SidebarContentBlock__title",
         },
@@ -160,13 +166,25 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "className": "iconfont icon-refresh InterestingPeople__icon-refresh",
+              "children": <i
+                className="iconfont icon-refresh"
+              />,
+              "className": "InterestingPeople__button-refresh",
               "onClick": [Function],
-              "role": "presentation",
             },
             "ref": null,
-            "rendered": null,
-            "type": "i",
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "className": "iconfont icon-refresh",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "i",
+            },
+            "type": "button",
           },
         ],
         "type": "h4",
@@ -352,11 +370,14 @@ ShallowWrapper {
               id="interesting_people"
               values={Object {}}
             />
-            <i
-              className="iconfont icon-refresh InterestingPeople__icon-refresh"
+            <button
+              className="InterestingPeople__button-refresh"
               onClick={[Function]}
-              role="presentation"
-            />
+            >
+              <i
+                className="iconfont icon-refresh"
+              />
+            </button>
           </h4>,
           <div
             className="SidebarContentBlock__content"
@@ -424,11 +445,14 @@ ShallowWrapper {
                 id="interesting_people"
                 values={Object {}}
               />,
-              <i
-                className="iconfont icon-refresh InterestingPeople__icon-refresh"
+              <button
+                className="InterestingPeople__button-refresh"
                 onClick={[Function]}
-                role="presentation"
-              />,
+              >
+                <i
+                  className="iconfont icon-refresh"
+                />
+              </button>,
             ],
             "className": "SidebarContentBlock__title",
           },
@@ -464,13 +488,25 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "className": "iconfont icon-refresh InterestingPeople__icon-refresh",
+                "children": <i
+                  className="iconfont icon-refresh"
+                />,
+                "className": "InterestingPeople__button-refresh",
                 "onClick": [Function],
-                "role": "presentation",
               },
               "ref": null,
-              "rendered": null,
-              "type": "i",
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "className": "iconfont icon-refresh",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "i",
+              },
+              "type": "button",
             },
           ],
           "type": "h4",


### PR DESCRIPTION
Fixes #1754 

### Changes

* Wrap `<i>` element inside button
* Style button so as to be invisible

### Test plan

* Visual inspection
* Tab through elements on webpage. Refresh icon can now be tabbed to.

### Demo (optional)

Screenshots (before & after) or video that show result of your work.
_Before:_
![screenshot from 2018-05-13 14-59-33](https://user-images.githubusercontent.com/28683099/39964374-44bc28b4-56be-11e8-83da-52517004fdbc.png)

_After:_
![screenshot from 2018-05-13 14-56-12](https://user-images.githubusercontent.com/28683099/39964359-e747a244-56bd-11e8-9c55-8a621ff3d393.png)

### Notes

- I've opted to remove the outline from the button element in order to be consistent with the rest of the site. However, there's an argument to be made from the accessibility point of view that it's important to have element outlines when they are focused. Let me know if you'd prefer to have this changed.

With outline enabled (after clicking on button):
![screenshot from 2018-05-13 15-06-55](https://user-images.githubusercontent.com/28683099/39964422-4f1d55de-56bf-11e8-8c6b-44dc99553791.png)

