### PR TITLE
fix: add missing contenthash to CSS

### DIFF
--- a/webpack/client.js
+++ b/webpack/client.js
@@ -94,7 +94,7 @@ module.exports = function createConfig(env = 'dev') {
         flattening: true,
       }),
       new CSSExtract({
-        filename: '[name].css',
+        filename: '[name].[contenthash].css',
       }),
       new BundleAnalyzerPlugin({
         analyzerMode: 'static',


### PR DESCRIPTION
Missing hash was likely causing issues with PWA caching styles.

### Changes

* add missing contenthash to CSS
