### PR TITLE
fix: prevent blocking screen

### DIFF
--- a/src/client/components/BBackTop.less
+++ b/src/client/components/BBackTop.less
@@ -4,14 +4,13 @@
 .BBackTop {
   position: fixed;
   width: 100%;
-  height: 70px;
-  bottom: 0;
-  left: 0;
+  height: 0px;
+  bottom: 60px;
+  right: 20px;
 
   .BBackTop__container {
     position: relative;
     margin: 0 auto;
-    padding: 0 20px;
     max-width: @container-width;
     @media @large {
       padding: 0;
@@ -29,6 +28,7 @@
     i {
       color: @primary-color !important;
       font-size: 40px;
+      line-height: 40px;
       background-color: white;
       border-radius: 50%;
 


### PR DESCRIPTION
Fixes #1861 

### Changes

* Prevent BBackTop component from blocking screen.

### Test plan

* [x] Go to: https://busy-master-pr-1864.herokuapp.com/
* [x] Scroll down and then up so BackTop shows up
* [x] Make sure that everything at the height of BackTop button is clickable.

