### PR TITLE
refactor: update prop types

### DIFF
--- a/src/client/components/Popover.js
+++ b/src/client/components/Popover.js
@@ -20,7 +20,7 @@ const PopoverContainer = props => (
 
 PopoverContainer.propTypes = {
   onVisibleChange: PropTypes.func,
-  content: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  content: PropTypes.node,
 };
 
 PopoverContainer.defaultProps = {

--- a/src/client/components/PopoverMenu/PopoverMenu.js
+++ b/src/client/components/PopoverMenu/PopoverMenu.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import PopoverMenuItem, { popoverMenuItemType } from './PopoverMenuItem';
+import PopoverMenuItem from './PopoverMenuItem';
 import './PopoverMenu.less';
 
 const PopoverMenu = ({ children, onSelect, bold }) => (
@@ -24,7 +24,7 @@ const PopoverMenu = ({ children, onSelect, bold }) => (
 );
 
 PopoverMenu.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.arrayOf(popoverMenuItemType), popoverMenuItemType]),
+  children: PropTypes.node,
   onSelect: PropTypes.func,
   bold: PropTypes.bool,
 };

--- a/src/client/components/PopoverMenu/PopoverMenuItem.js
+++ b/src/client/components/PopoverMenu/PopoverMenuItem.js
@@ -24,7 +24,7 @@ const PopoverMenuItem = ({ itemKey, children, onClick, bold, disabled, fullScree
 );
 
 PopoverMenuItem.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.node,
   itemKey: PropTypes.string,
   onClick: PropTypes.func,
   bold: PropTypes.bool,
@@ -40,9 +40,5 @@ PopoverMenuItem.defaultProps = {
   disabled: false,
   fullScreenHidden: false,
 };
-
-export const popoverMenuItemType = PropTypes.shape({
-  type: PropTypes.oneOf([PopoverMenuItem]),
-});
 
 export default PopoverMenuItem;

--- a/src/client/components/UserCard.js
+++ b/src/client/components/UserCard.js
@@ -22,7 +22,7 @@ const UserCard = ({ username, alt }) => (
 
 UserCard.propTypes = {
   username: PropTypes.string.isRequired,
-  alt: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  alt: PropTypes.node,
 };
 
 UserCard.defaultProps = {

--- a/src/client/vendor/ReduxInfiniteScroll.js
+++ b/src/client/vendor/ReduxInfiniteScroll.js
@@ -158,14 +158,8 @@ ReduxInfiniteScroll.propTypes = {
   loader: PropTypes.any,
   showLoader: PropTypes.bool,
   loadMore: PropTypes.func.isRequired,
-  items: PropTypes.oneOfType([
-    //ImmutablePropTypes.list,
-    PropTypes.array,
-  ]),
-  children: PropTypes.oneOfType([
-    //ImmutablePropTypes.list,
-    PropTypes.array,
-  ]),
+  items: PropTypes.node,
+  children: PropTypes.node,
   holderType: PropTypes.string,
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };


### PR DESCRIPTION
Some props were failing (PopoverMenu), I updated other as well to use standard `node` proptype.

### Changes

* Use `node` for children props.
