### PR TITLE
fix: rewrite links before sanitisation

### DIFF
--- a/src/client/components/Story/Body.js
+++ b/src/client/components/Story/Body.js
@@ -53,18 +53,19 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object', options 
 
   const htmlReadyOptions = { mutate: true, resolveIframe: returnType === 'text' };
   parsedBody = remarkable.render(parsedBody);
-  parsedBody = htmlReady(parsedBody, htmlReadyOptions).html;
-  parsedBody = parsedBody.replace(dtubeImageRegex, '');
-  parsedBody = sanitizeHtml(parsedBody, sanitizeConfig({}));
-  if (returnType === 'text') {
-    return parsedBody;
-  }
 
   if (options.rewriteLinks) {
     parsedBody = parsedBody.replace(
       /"https?:\/\/(?:www)?steemit.com\/([A-Za-z0-9@/\-.]*)"/g,
       (match, p1) => `"/${p1}"`,
     );
+  }
+
+  parsedBody = htmlReady(parsedBody, htmlReadyOptions).html;
+  parsedBody = parsedBody.replace(dtubeImageRegex, '');
+  parsedBody = sanitizeHtml(parsedBody, sanitizeConfig({}));
+  if (returnType === 'text') {
+    return parsedBody;
   }
 
   parsedBody = parsedBody.replace(


### PR DESCRIPTION
Fixes #1862 

### Changes
* rewrite links before sanitisation

### Test plan

* [x] Go to: https://busy-master-pr-1867.herokuapp.com/@rivalhw/steemit-t
* [x] Make sure you are logged in and have URL rewriting enabled.
* [x] Steemit link should be rewritten instead of replacing it with ExitPage.
