### PR TITLE
fix: don't render preview to HTML twice

### DIFF
--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -8,7 +8,6 @@ import _ from 'lodash';
 import readingTime from 'reading-time';
 import { Checkbox, Form, Input, Select, Button } from 'antd';
 import { rewardsValues } from '../../../common/constants/rewards';
-import improve from '../../helpers/improve';
 import Action from '../Button/Action';
 import requiresLogin from '../../auth/requiresLogin';
 import withEditor from './withEditor';
@@ -65,6 +64,7 @@ class Editor extends React.Component {
     super(props);
 
     this.state = {
+      body: '',
       bodyHTML: '',
     };
 
@@ -133,7 +133,8 @@ class Editor extends React.Component {
 
   setBodyAndRender(body) {
     this.setState({
-      bodyHTML: remarkable.render(improve(body)),
+      body,
+      bodyHTML: remarkable.render(body),
     });
   }
 
@@ -196,7 +197,7 @@ class Editor extends React.Component {
   render() {
     const { intl, form, loading, isUpdating, saving, draftId } = this.props;
     const { getFieldDecorator } = form;
-    const { bodyHTML } = this.state;
+    const { body, bodyHTML } = this.state;
 
     const { words, minutes } = readingTime(bodyHTML);
 
@@ -319,7 +320,7 @@ class Editor extends React.Component {
             />,
           )}
         </Form.Item>
-        {bodyHTML && (
+        {body && (
           <Form.Item
             label={
               <span className="Editor__label">
@@ -327,7 +328,7 @@ class Editor extends React.Component {
               </span>
             }
           >
-            <Body full body={bodyHTML} />
+            <Body full body={body} />
           </Form.Item>
         )}
         <Form.Item

--- a/src/client/components/Story/Body.js
+++ b/src/client/components/Story/Body.js
@@ -10,6 +10,7 @@ import { jsonParse } from '../../helpers/formatter';
 import sanitizeConfig from '../../vendor/SanitizeConfig';
 import { imageRegex, dtubeImageRegex } from '../../helpers/regexHelpers';
 import htmlReady from '../../vendor/steemitHtmlReady';
+import improve from '../../helpers/improve';
 import PostFeedEmbed from './PostFeedEmbed';
 import './Body.less';
 
@@ -52,6 +53,7 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object', options 
   });
 
   const htmlReadyOptions = { mutate: true, resolveIframe: returnType === 'text' };
+  parsedBody = improve(parsedBody);
   parsedBody = remarkable.render(parsedBody);
   parsedBody = htmlReady(parsedBody, htmlReadyOptions).html;
   parsedBody = parsedBody.replace(dtubeImageRegex, '');


### PR DESCRIPTION
Fixes #1849 

### Changes

* Render Preview by Body only.

### Test plan

* [x] Open this PR deployment
* [x] Create new post with content (wrapped with 3 `)

    ```
    test line
    
    another line
    
    another another
    ```
* [x] It should render code with properly aligned text.

### Demo

Before:
![image](https://user-images.githubusercontent.com/1968722/40145725-41ea63b0-5963-11e8-8c27-fe4b83473f4a.png)


After:
![image](https://user-images.githubusercontent.com/1968722/40145704-31216d58-5963-11e8-90d9-8f3ba823ed92.png)

