### PR TITLE
Add parentheses for calculations of comment width offset

### DIFF
--- a/src/client/components/Comments/Comment.less
+++ b/src/client/components/Comments/Comment.less
@@ -17,7 +17,7 @@
 }
 
 .Comments > .Comment > .Comment__text {
-  width: calc(~'100% - @{comment-text-offset-default}');
+  width: calc(~'100% - (@{comment-text-offset-default})');
 }
 
 .Comment {
@@ -58,7 +58,7 @@
 
   &__text {
     position: relative;
-    width: calc(~'100% - @{comment-text-offset-small}');
+    width: calc(~'100% - (@{comment-text-offset-small})');
     margin-left: @comment-text-left-margin;
     overflow: unset;
 


### PR DESCRIPTION
Fixes #1836

### Changes

- Add parantheses for comment text offset calculations, was breaking due to order of operations

### Test plan

Explain how to test changes you made.

* [x] Go to this url - https://busy-master-pr-1873.herokuapp.com/@scipio/learn-python-series-23-handling-regular-expressions-part-1#@nomannomi/re-scipio-learn-python-series-23-handling-regular-expressions-part-1-20180507t190651517z

### Demo (optional)

# Before

![screen shot 2018-05-18 at 1 09 48 pm](https://user-images.githubusercontent.com/5067716/40248100-cab3cbde-5a9c-11e8-9d93-1669e904e2f5.png)

# After
![screen shot 2018-05-18 at 1 09 06 pm](https://user-images.githubusercontent.com/5067716/40248113-d188ac9a-5a9c-11e8-8e08-419ebf2b9406.png)

