### PR TITLE
fix: use BusyIPFS links in comment previews

### DIFF
--- a/src/client/components/Comments/CommentForm.js
+++ b/src/client/components/Comments/CommentForm.js
@@ -137,7 +137,7 @@ class CommentForm extends React.Component {
               <span className="Editor__label">
                 <FormattedMessage id="preview" defaultMessage="Preview" />
               </span>
-              <Body body={bodyHTML} />
+              <Body preview body={bodyHTML} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Fixes #1880 

### Changes

* Add `preview` prop to Body component.

### Test plan

* [x] Start writing a comment and add image.
* [x] Preview image should be served from ipfs.busy.org (text still should show gateway.ipfs.io).
* [x] Send comment.
* [x] Comment should use gateway.ipfs.io.

