### PR TITLE
fix: don't use proxy for gateway.ipfs.io URLs

### DIFF
--- a/src/client/helpers/image.js
+++ b/src/client/helpers/image.js
@@ -8,7 +8,7 @@ export const MAXIMUM_UPLOAD_SIZE = 15728640;
 export const MAXIMUM_UPLOAD_SIZE_HUMAN = filesize(MAXIMUM_UPLOAD_SIZE);
 
 export const getProxyImageURL = (url, type) => {
-  if (url.indexOf('https://ipfs.busy.org') === 0) {
+  if (url.indexOf('https://ipfs.busy.org') === 0 || url.indexOf('https://gateway.ipfs.io') === 0) {
     return url;
   } else if (type === 'preview') {
     return `${IMG_PROXY_PREVIEW}${url}`;


### PR DESCRIPTION
Fixes #1882 

### Changes

* Check if image URL starts with gateway URL.

### Test plan

* [x] Go to: https://busy-master-pr-1883.herokuapp.com/@hellosteem/6jq3so-test
* [x] Make sure all IPFS urls aren't using SteemitImages.

