### PR TITLE
fix: preserve hash in ExitPage

### DIFF
--- a/src/client/statics/ExitPage.js
+++ b/src/client/statics/ExitPage.js
@@ -10,6 +10,7 @@ import './ExitPage.less';
 export default class ExitPage extends React.Component {
   static propTypes = {
     intl: PropTypes.shape().isRequired,
+    location: PropTypes.shape().isRequired,
   };
 
   closeWindow = () => {
@@ -19,8 +20,9 @@ export default class ExitPage extends React.Component {
   };
 
   render() {
-    const { intl } = this.props;
-    const url = new URLSearchParams(location.search).get('url');
+    const { intl, location } = this.props;
+
+    const url = `${new URLSearchParams(location.search).get('url')}${location.hash}`;
 
     if (!url) {
       return null;

--- a/src/client/statics/ExitPage.js
+++ b/src/client/statics/ExitPage.js
@@ -13,26 +13,6 @@ export default class ExitPage extends React.Component {
     location: PropTypes.shape().isRequired,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      url: null,
-    };
-  }
-
-  componentDidMount() {
-    if (typeof window !== 'undefined') this.getUrl();
-  }
-
-  getUrl = () => {
-    const { location } = this.props;
-
-    this.setState({
-      url: `${new URLSearchParams(location.search).get('url')}${location.hash}`,
-    });
-  };
-
   closeWindow = () => {
     if (typeof window !== 'undefined') {
       window.close();
@@ -40,8 +20,9 @@ export default class ExitPage extends React.Component {
   };
 
   render() {
-    const { intl } = this.props;
-    const { url } = this.state;
+    const { intl, location } = this.props;
+
+    const url = decodeURIComponent(new URLSearchParams(location.search).get('url'));
 
     if (!url) return <div />;
 

--- a/src/client/statics/ExitPage.js
+++ b/src/client/statics/ExitPage.js
@@ -13,6 +13,26 @@ export default class ExitPage extends React.Component {
     location: PropTypes.shape().isRequired,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      url: null,
+    };
+  }
+
+  componentDidMount() {
+    if (typeof window !== 'undefined') this.getUrl();
+  }
+
+  getUrl = () => {
+    const { location } = this.props;
+
+    this.setState({
+      url: `${new URLSearchParams(location.search).get('url')}${location.hash}`,
+    });
+  };
+
   closeWindow = () => {
     if (typeof window !== 'undefined') {
       window.close();
@@ -20,13 +40,10 @@ export default class ExitPage extends React.Component {
   };
 
   render() {
-    const { intl, location } = this.props;
+    const { intl } = this.props;
+    const { url } = this.state;
 
-    const url = `${new URLSearchParams(location.search).get('url')}${location.hash}`;
-
-    if (!url) {
-      return null;
-    }
+    if (!url) return <div />;
 
     return (
       <div className="ExitPage container">

--- a/src/client/vendor/SanitizeConfig.js
+++ b/src/client/vendor/SanitizeConfig.js
@@ -163,7 +163,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [], secureLink
       // If it's not a (relative or absolute) steemit URL...
       if (secureLinks && !href.match(/^^(\/|https:\/\/(staging\.)?busy\.org(?![\w\.]+))/)) {
         attys.target = '_blank';
-        href = `/exit?url=${encodeURI(href)}`;
+        href = `/exit?url=${encodeURIComponent(href)}`;
       }
       attys.href = href;
       return {


### PR DESCRIPTION
Fixes #1877 

### Changes

* Use `react-intl` location.
* Add missing hash

### Test plan

* [x] Go to: https://busy-master-pr-1884.herokuapp.com/@leatherdog-games/far-horizons-steem-start-of-turn-7-game-1526338556
* [x] Click on external link.
* [x] ExitPage should show up.
* [x] URL should contain hash, and after visiting website hash should still be in URL.

