### PR TITLE
feat: use BusyIPFS links

### DIFF
--- a/src/client/components/Comments/CommentForm.js
+++ b/src/client/components/Comments/CommentForm.js
@@ -137,7 +137,7 @@ class CommentForm extends React.Component {
               <span className="Editor__label">
                 <FormattedMessage id="preview" defaultMessage="Preview" />
               </span>
-              <Body preview body={bodyHTML} />
+              <Body body={bodyHTML} />
             </div>
           )}
         </div>

--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -328,7 +328,7 @@ class Editor extends React.Component {
               </span>
             }
           >
-            <Body full preview body={body} />
+            <Body full body={body} />
           </Form.Item>
         )}
         <Form.Item

--- a/src/client/components/Story/Body.js
+++ b/src/client/components/Story/Body.js
@@ -46,13 +46,6 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object', options 
 
   parsedBody = parsedBody.replace(/^\s+</gm, '<');
 
-  if (options.preview) {
-    parsedBody = parsedBody.replace(
-      /https:\/\/gateway\.ipfs\.io\/ipfs\/(\w+)/gm,
-      (match, p1) => `https://ipfs.busy.org/ipfs/${p1}`,
-    );
-  }
-
   parsedBody.replace(imageRegex, img => {
     if (_.filter(parsedJsonMetadata.image, i => i.indexOf(img) !== -1).length === 0) {
       parsedJsonMetadata.image.push(img);
@@ -111,7 +104,6 @@ const Body = props => {
   const options = {
     rewriteLinks: props.rewriteLinks,
     secureLinks: true,
-    preview: props.preview,
   };
   const htmlSections = getHtml(props.body, props.jsonMetadata, 'Object', options);
   return <div className={classNames('Body', { 'Body--full': props.full })}>{htmlSections}</div>;
@@ -121,7 +113,6 @@ Body.propTypes = {
   body: PropTypes.string,
   jsonMetadata: PropTypes.string,
   full: PropTypes.bool,
-  preview: PropTypes.bool,
   rewriteLinks: PropTypes.bool,
 };
 
@@ -129,7 +120,6 @@ Body.defaultProps = {
   body: '',
   jsonMetadata: '',
   full: false,
-  preview: false,
   rewriteLinks: false,
 };
 


### PR DESCRIPTION
Fixes #1887 

### Changes

* Delete code that conditionally updated IPFS links.
* Use default link (ipfs.busy.org)

### Test plan

* [x] Insert new image in editor.
* [x] It should use ipfs.busy.org.
* [x] Create new post with image.
* [x] It should use ipfs.busy.org as well.

