### PR TITLE
fix: ignore reblogged props from GET_CONTENT

### DIFF
--- a/src/client/post/postsReducer.js
+++ b/src/client/post/postsReducer.js
@@ -82,13 +82,19 @@ const posts = (state = initialState, action) => {
         },
       };
     case postsActions.GET_CONTENT.SUCCESS: {
+      const {
+        reblogged_by: rebloggedBy,
+        first_reblogged_on: firstRebloggedOn,
+        ...newPost
+      } = action.payload;
+
       const baseState = {
         ...state,
         list: {
           ...state.list,
           [action.payload.id]: {
-            ...state[action.payload.id],
-            ...action.payload,
+            ...state.list[action.payload.id],
+            ...newPost,
           },
         },
         postsStates: {


### PR DESCRIPTION
Fixes #1886 

### Changes

* Ignore `reblogged_by` and `first_reblogged_on` from GET_CONTENT response.

### Test plan

* [x] Go to: http://localhost:3000/@hellosteem
* [x] Upvote one of reblogged posts.
* [x] Reblogged indicator should not disappear.
