### PR TITLE
Add binance deposit account to exchange accounts

### DIFF
--- a/src/client/wallet/Transfer.js
+++ b/src/client/wallet/Transfer.js
@@ -58,7 +58,7 @@ export default class Transfer extends React.Component {
 
   static minAccountLength = 3;
   static maxAccountLength = 16;
-  static exchangeRegex = /^(bittrex|blocktrades|poloniex|changelly|openledge|shapeshiftio)$/;
+  static exchangeRegex = /^(bittrex|blocktrades|poloniex|changelly|openledge|shapeshiftio|deepcrypto8)$/;
   static CURRENCIES = {
     STEEM: 'STEEM',
     SBD: 'SBD',


### PR DESCRIPTION
[deepcrypto8](https://steemit.com/@deepcrypto8) is the deposit account of [Binance](https://binance.com) exchange.

### Changes

When you try to transfer any SBD/STEEM to exchanges, the interface warns the user that they should put a memo. Binance's deposit account was not listed here, I have added it.

### Test plan

Explain how to test changes you made.

* [ ] Try to transfer 0.001 SBD or 0.001 STEEM to deepcrypto8
* [ ] Check the warning message pops up

### Demo 

**Before**

<img width="521" alt="screen shot 2018-05-22 at 7 47 33 pm" src="https://user-images.githubusercontent.com/72460/40377353-65ce42de-5df9-11e8-8825-54f842ecf420.png">

**After**

<img width="521" alt="screen shot 2018-05-22 at 5 32 11 pm" src="https://user-images.githubusercontent.com/72460/40377361-6ba7db34-5df9-11e8-8b62-dcfeced9cfc0.png">
