### PR TITLE
fix: update steemitmages URL

### DIFF
--- a/src/client/components/Avatar.js
+++ b/src/client/components/Avatar.js
@@ -4,8 +4,8 @@ import './Avatar.less';
 
 export function getAvatarURL(username, size = 100) {
   return size > 64
-    ? `https://steemitimages.com/u/${username}/avatar`
-    : `https://steemitimages.com/u/${username}/avatar/small`;
+    ? `https://images.steemitimages.com/u/${username}/avatar`
+    : `https://images.steemitimages.com/u/${username}/avatar/small`;
 }
 
 const Avatar = ({ username, size }) => {

--- a/src/client/components/AvatarLightbox.js
+++ b/src/client/components/AvatarLightbox.js
@@ -32,7 +32,7 @@ export default class AvatarLightbox extends React.Component {
         </a>
         {this.state.open && (
           <Lightbox
-            mainSrc={`https://steemitimages.com/u/${username}/avatar/large`}
+            mainSrc={`https://images.steemitimages.com/u/${username}/avatar/large`}
             onCloseRequest={this.handleCloseRequest}
           />
         )}

--- a/src/client/components/UserHeader.js
+++ b/src/client/components/UserHeader.js
@@ -25,7 +25,7 @@ const UserHeader = ({
   onTransferClick,
 }) => {
   const style = hasCover
-    ? { backgroundImage: `url("https://steemitimages.com/2048x512/${coverImage}")` }
+    ? { backgroundImage: `url("https://images.steemitimages.com/2048x512/${coverImage}")` }
     : {};
   return (
     <div className={classNames('UserHeader', { 'UserHeader--cover': hasCover })} style={style}>

--- a/src/client/helpers/image.js
+++ b/src/client/helpers/image.js
@@ -1,8 +1,8 @@
 import filesize from 'filesize';
 
-const IMG_PROXY = 'https://steemitimages.com/0x0/';
-const IMG_PROXY_PREVIEW = 'https://steemitimages.com/600x800/';
-const IMG_PROXY_SMALL = 'https://steemitimages.com/40x40/';
+const IMG_PROXY = 'https://images.steemitimages.com/0x0/';
+const IMG_PROXY_PREVIEW = 'https://images.steemitimages.com/600x800/';
+const IMG_PROXY_SMALL = 'https://images.steemitimages.com/40x40/';
 
 export const MAXIMUM_UPLOAD_SIZE = 15728640;
 export const MAXIMUM_UPLOAD_SIZE_HUMAN = filesize(MAXIMUM_UPLOAD_SIZE);


### PR DESCRIPTION
Fixes #1896 

### Changes
* update steemitmages URL to `images.steemitimages.com`

### Test plan

* [x] Images should work.

