### PR TITLE
fix: replace post link from modal

### DIFF
--- a/src/client/post/PostModal.js
+++ b/src/client/post/PostModal.js
@@ -120,7 +120,7 @@ class PostModal extends React.Component {
           <a role="presentation" onClick={this.handleHidePostModal} className="PostModal__action">
             <i className="iconfont icon-close PostModal__icon" />
           </a>
-          <Link to={`/@${author}/${permlink}`} className="PostModal__action">
+          <Link replace to={`/@${author}/${permlink}`} className="PostModal__action">
             <i className="iconfont icon-send PostModal__icon" />
           </Link>
           <a href={twitterShareURL} target="_blank" className="PostModal__action">


### PR DESCRIPTION
Fixes #1899 

### Changes

* Replace post URL instead of adding new entry.

### Test plan

* [x] Go to feed.
* [x] Click on some post.
* [x] Click on second icon from top.
* [x] It should take you to single post view.
* [x] Hit back in browser.
* [x] You should be on feed page.
