### PR TITLE
fix: extract images

### DIFF
--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -205,7 +205,7 @@ class Write extends React.Component {
 
     const parsedBody = getHtml(postBody, {}, 'text');
 
-    const images = _.map(extractImageTags, tag => tag.src);
+    const images = extractImageTags(parsedBody).map(tag => tag.src);
     const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -205,7 +205,9 @@ class Write extends React.Component {
 
     const parsedBody = getHtml(postBody, {}, 'text');
 
-    const images = extractImageTags(parsedBody).map(tag => tag.src);
+    const images = extractImageTags(parsedBody).map(tag =>
+      tag.src.replace('https://steemitimages.com/0x0/', ''),
+    );
     const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {


### PR DESCRIPTION
Fixes #1907 

### Changes

* Fix bug introduced in #1765

### Test plan

* [X] Create new post with BusyIPFS image and some external image
  ```
  dasdasdsa

  das
  dsa
  ![image.png](https://ipfs.busy.org/ipfs/QmUYDaJqFWrhvGQfnAxLCQ7hqDd1eKRNZomayXvrvJpq76)
  ![aa](https://i.imgur.com/Cg3Pq45.jpg)
  dsa
  dsa
  sad
  ```
* [X] Both images should be visible in metadata.
