### PR TITLE
feat: use 100% width for layout

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -208,7 +208,7 @@ export default class Wrapper extends React.PureComponent {
       <IntlProvider key={language.id} locale={language.localeData} messages={translations}>
         <LocaleProvider locale={enUS}>
           <Layout data-dir={language && language.rtl ? 'rtl' : 'ltr'}>
-            <Layout.Header style={{ position: 'fixed', width: '100vw', zIndex: 1050 }}>
+            <Layout.Header style={{ position: 'fixed', width: '100%', zIndex: 1050 }}>
               <Topnav username={user.name} onMenuItemClick={this.handleMenuItemClick} />
             </Layout.Header>
             <div className="content">

--- a/src/client/styles/common.less
+++ b/src/client/styles/common.less
@@ -20,7 +20,7 @@ a:focus {
 
 .content {
   margin-top: 56px;
-  width: 100vw;
+  width: 100%;
 }
 
 .shifted {


### PR DESCRIPTION
Fixes #1809

### Changes

*  Use 100% instead of 100vw for layout width.

### Test plan

* [x] Minimise window so two columns are visible.
* [x] There should be equal padding on both sides.

### Demo

Before:
![image](https://user-images.githubusercontent.com/1968722/40626552-a3337d14-62b9-11e8-8b70-fa08c850f383.png)

After:
![image](https://user-images.githubusercontent.com/1968722/40626554-aa3769f4-62b9-11e8-94b9-a1990bf4652d.png)

