### PR TITLE
Transfer notification link to wallet instead of sender profile

### DIFF
--- a/src/client/components/Navigation/Notifications/NotificationTransfer.js
+++ b/src/client/components/Navigation/Notifications/NotificationTransfer.js
@@ -9,7 +9,7 @@ import './Notification.less';
 
 const NotificationTransfer = ({ notification, read, onClick }) => (
   <Link
-    to="wallet"
+    to="/wallet"
     className={classNames('Notification', {
       'Notification--unread': !read,
     })}

--- a/src/client/components/Navigation/Notifications/NotificationTransfer.js
+++ b/src/client/components/Navigation/Notifications/NotificationTransfer.js
@@ -9,7 +9,7 @@ import './Notification.less';
 
 const NotificationTransfer = ({ notification, read, onClick }) => (
   <Link
-    to={`/wallet`}
+    to="wallet"
     className={classNames('Notification', {
       'Notification--unread': !read,
     })}

--- a/src/client/components/Navigation/Notifications/NotificationTransfer.js
+++ b/src/client/components/Navigation/Notifications/NotificationTransfer.js
@@ -9,7 +9,7 @@ import './Notification.less';
 
 const NotificationTransfer = ({ notification, read, onClick }) => (
   <Link
-    to={`/@${notification.from}`}
+    to={`/wallet`}
     className={classNames('Notification', {
       'Notification--unread': !read,
     })}


### PR DESCRIPTION
This is the change suggested in #1890.

When user clicks on a received transfer notification send them to the wallet page instead of profile of user who sent the transfer.