### PR TITLE
Remove unused package js-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "identity-obj-proxy": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.1.4",
-    "js-logger": "^1.3.0",
     "lightrpc": "0.0.1",
     "lodash": "^4.0.0",
     "matchmedia": "^0.1.2",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,7 +2,6 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import Logger from 'js-logger';
 import { message } from 'antd';
 import Cookie from 'js-cookie';
 import steemConnectAPI from './steemConnectAPI';
@@ -12,8 +11,6 @@ import AppHost from './AppHost';
 import { getBrowserLocale, loadLanguage } from './translations';
 import { setUsedLocale } from './app/appActions';
 import { getLocale } from './reducers';
-
-Logger.useDefaults();
 
 if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
   navigator.serviceWorker.register('/service-worker.js');


### PR DESCRIPTION
This removes an unused package `js-logger` was assigned #1812 to other developer but left open 29 days.