### PR TITLE
Fix: Make Copy button's positioning relative on invite page (#1443)

### DIFF
--- a/src/client/invite/Invite.less
+++ b/src/client/invite/Invite.less
@@ -55,9 +55,11 @@
       color: @white;
       padding: 4px 10px;
       position: absolute;
-      margin-left: -90px;
+      margin-left: -8px;
       margin-top: 7px;
       cursor: pointer;
+      transform: translateX(-100%);
+      white-space: nowrap;
 
       &:hover {
         opacity: 0.8;


### PR DESCRIPTION
Fixes #1443.

### Changes

Updated copy button's style on invite page. It now uses a relative positioning. 

### Test plan

For *English* version:

* [x] Click "Copy"
* [x] Make sure "Copied" text (after clicking to copy) doesn't pull the button left and create blank space in the right of the button.

For *Czech* and *Turkish* versions:

* [x] Make sure "copy" button is not overflowed to the right. (Before and after clicking the "copy")

### Demo (optional)

**Before (English)** 

<img width="507" alt="screen shot 2018-05-31 at 11 48 13 am" src="https://user-images.githubusercontent.com/72460/40773136-a3c58dea-64ca-11e8-965a-9a16844449ff.png">

**After (English)**

<img width="494" alt="screen shot 2018-05-31 at 11 48 20 am" src="https://user-images.githubusercontent.com/72460/40773148-ab4fb0e0-64ca-11e8-81ca-da198d7dd3d8.png">

**Before (Turkish)**
<img width="516" alt="screen shot 2018-05-31 at 11 49 15 am" src="https://user-images.githubusercontent.com/72460/40773186-c96fb368-64ca-11e8-9783-5f6323a57b7f.png">

**After (Turkish)**  
<img width="497" alt="screen shot 2018-05-31 at 11 49 24 am" src="https://user-images.githubusercontent.com/72460/40773446-93dfd236-64cb-11e8-9bd3-e35b962fbbbb.png">


**Before (Czech)** 

<img width="540" alt="screen shot 2018-05-31 at 11 50 03 am" src="https://user-images.githubusercontent.com/72460/40773201-d4382af0-64ca-11e8-87fd-86bfcb9fea6c.png">

**After (Czech)** 

<img width="504" alt="screen shot 2018-05-31 at 11 50 14 am" src="https://user-images.githubusercontent.com/72460/40773214-d920adb2-64ca-11e8-8b80-a534bc78b028.png">
