### PR TITLE
Fix vertical alignment of Transfer amount model

### DIFF
--- a/src/client/wallet/Transfer.less
+++ b/src/client/wallet/Transfer.less
@@ -54,6 +54,14 @@
         .ant-input-group-addon {
           text-align: right;
           width: 160px !important;
+          position: relative;
+        }
+
+        .ant-radio-group {
+          position: relative;
+          top: 50%;
+          -webkit-transform: translateY(-50%);
+          transform: translateY(-50%);
         }
       }
     }


### PR DESCRIPTION

Fixes #
https://github.com/busyorg/busy/issues/1905

### Changes
Summary of changes you made.

* It moves model from top alignment to center alignment

### Test plan

Explain how to test changes you made.

* Go to http://localhost:3000/@husaini/transfers
* Click on 'Transfer' button

### Demo (optional)

Before is available in issue: https://github.com/busyorg/busy/issues/1905

After:


<img width="492" alt="screen shot 2018-06-02 at 10 43 17" src="https://user-images.githubusercontent.com/6135761/40872676-839507a6-6652-11e8-97d5-15faa0b103db.png">

<img width="552" alt="screen shot 2018-06-02 at 10 43 10" src="https://user-images.githubusercontent.com/6135761/40872680-8b692214-6652-11e8-8923-8fc8514e8537.png">

<img width="492" alt="screen shot 2018-06-02 at 10 43 17" src="https://user-images.githubusercontent.com/6135761/40872681-8b83e810-6652-11e8-9a35-e8ea14b04dd8.png">



