### PR TITLE
Show negative votes' value in reaction modal

### DIFF
--- a/src/client/components/Reactions/ReactionsModal.js
+++ b/src/client/components/Reactions/ReactionsModal.js
@@ -62,7 +62,7 @@ class ReactionsModal extends React.Component {
           }
           key="2"
         >
-          <ReactionsList votes={downVotes} />
+          <ReactionsList votes={downVotes} ratio={ratio} />
         </Tabs.TabPane>,
       );
     }

--- a/src/client/components/Utils/USDDisplay.js
+++ b/src/client/components/Utils/USDDisplay.js
@@ -2,12 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedNumber } from 'react-intl';
 
-const USDDisplay = ({ value }) => (
-  <span>
-    {'$'}
-    <FormattedNumber value={value} minimumFractionDigits={2} maximumFractionDigits={2} />
-  </span>
-);
+const USDDisplay = ({ value }) => {
+  const negative = value.toFixed(2) < 0;
+  const absValue = Math.abs(value);
+  return (
+    <span>
+      {negative && '-'}
+      {'$'}
+      <FormattedNumber value={absValue} minimumFractionDigits={2} maximumFractionDigits={2} />
+    </span>
+  );
+};
 
 USDDisplay.propTypes = {
   value: PropTypes.number,

--- a/src/client/components/__tests__/USSDDisplay.js
+++ b/src/client/components/__tests__/USSDDisplay.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { IntlProvider } from 'react-intl';
+import USSDDisplay from '../Utils/USDDisplay';
+
+const getWrapper = value =>
+  mount(
+    <IntlProvider locale="en">
+      <USSDDisplay value={value} />
+    </IntlProvider>,
+  );
+
+describe('<USSDDisplay />', () => {
+  it('shows positive numbers properly', () => {
+    const wrapper = getWrapper(44.36125);
+    expect(wrapper.text()).toEqual('$44.36');
+  });
+
+  it('handles negative values properly', () => {
+    const wrapper = getWrapper(-1.33);
+    expect(wrapper.text()).toEqual('-$1.33');
+  });
+
+  it('skips - for number small negative numebrs', () => {
+    const wrapper = getWrapper(-0.001);
+    expect(wrapper.text()).toEqual('$0.00');
+  });
+});


### PR DESCRIPTION
Fixes #1947. 

### Changes

* Use the ratio to calculate `value`.
* Change `USSDDisplay` to display negative numbers as `-$4.99` and not `$-4.99`.

### Test plan

* [x] Check rendering of positive numbers with round off
* [x] Check rendering of negative numbers to show `-$1.33` instead of `$-1.33`.
* [x] Check rendering of negative numbers to skip - for small numbers - `$0.00` and not `-$0.00` for -0.001.

### Demo (optional)

Sreenshots (before & after) or video that show result of your work.

| Before | After |
|---|---|
| ![screenshot from 2018-06-10 02-24-12](https://user-images.githubusercontent.com/10860278/41196038-d0811dbc-6c55-11e8-9527-24f699cda197.png) | ![screenshot from 2018-06-10 02-24-08](https://user-images.githubusercontent.com/10860278/41196041-d347fb74-6c55-11e8-8f67-2e5603093c5b.png)  |

