### PR TITLE
Define the white domains list in an helper

### DIFF
--- a/src/client/helpers/exitPageHelper.js
+++ b/src/client/helpers/exitPageHelper.js
@@ -1,0 +1,11 @@
+export const whitelistDomains = [
+  'steemit.com',
+  'steem.io',
+  'd.tube',
+  'dlive.io',
+  'utopian.io',
+  'coinmarketcap.com',
+  'youtube.com',
+];
+
+export default whitelistDomains;

--- a/src/client/statics/ExitPage.js
+++ b/src/client/statics/ExitPage.js
@@ -4,6 +4,7 @@ import 'url-search-params-polyfill';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import ActionLink from '../components/Button/ActionLink';
 import ActionButton from '../components/Button/Action';
+import { whitelistDomains } from '../helpers/exitPageHelper';
 import './ExitPage.less';
 
 @injectIntl
@@ -12,6 +13,14 @@ export default class ExitPage extends React.Component {
     intl: PropTypes.shape().isRequired,
     location: PropTypes.shape().isRequired,
   };
+
+  componentWillMount() {
+    const url = decodeURIComponent(new URLSearchParams(location.search).get('url'));
+    const hostname = new URL(url).hostname;
+    if (whitelistDomains.includes(hostname.replace(/^[^.]+\./g, ''))) {
+      window.location = url;
+    }
+  }
 
   closeWindow = () => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
Extract the domain from url and redirect directly

Fixes #1931 

### Changes

Add a white domains list in an helper
Extract the domain from an url and redirect immediately if it's in the whitelist

### Test plan

Open the post https://busy.org/@utopian-io/people-of-utopian-4-knowledges and click on the utopian.io link => you're redirected immediately

Open the post https://busy.org/@kaleem345/be-smart-no-1-cares-about-your-effort-only-the-results-zg1hbmlh-w3z9r => you're on the exit page
