### PR TITLE
refactor: extract images from parsed body

### DIFF
--- a/src/client/components/Sidebar/PostRecommendationLink.js
+++ b/src/client/components/Sidebar/PostRecommendationLink.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { FormattedMessage, FormattedNumber, FormattedRelative } from 'react-intl';
 import { getFromMetadata } from '../../helpers/parser';
 import { getProxyImageURL } from '../../helpers/image';
-import { image } from '../../vendor/steemitLinks';
+import { getContentImages } from '../../helpers/postHelpers';
 
 const PostRecommendationLink = ({ post, navigateToPost, navigateToPostComments }) => {
   const images = getFromMetadata(post.json_metadata, 'image');
@@ -15,9 +15,9 @@ const PostRecommendationLink = ({ post, navigateToPost, navigateToPostComments }
   if (images && firstImage) {
     imagePath = getProxyImageURL(firstImage, 'small');
   } else {
-    const bodyImg = post.body.match(image());
-    if (bodyImg && bodyImg.length) {
-      imagePath = getProxyImageURL(bodyImg[0], 'small');
+    const contentImages = getContentImages(post.body);
+    if (contentImages.length) {
+      imagePath = getProxyImageURL(contentImages[0], 'small');
     }
   }
 

--- a/src/client/components/Story/StoryPreview.js
+++ b/src/client/components/Story/StoryPreview.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import PostFeedEmbed from './PostFeedEmbed';
 import BodyShort from './BodyShort';
 import { jsonParse } from '../../helpers/formatter';
-import { image } from '../../vendor/steemitLinks';
+import { getContentImages } from '../../helpers/postHelpers';
 import {
   getPositions,
   postWithPicture,
@@ -25,9 +25,9 @@ const StoryPreview = ({ post }) => {
   if (jsonMetadata.image && jsonMetadata.image[0]) {
     imagePath = getProxyImageURL(jsonMetadata.image[0], 'preview');
   } else {
-    const bodyImg = post.body.match(image());
-    if (bodyImg && bodyImg.length) {
-      imagePath = getProxyImageURL(bodyImg[0], 'preview');
+    const contentImages = getContentImages(post.body);
+    if (contentImages.length) {
+      imagePath = getProxyImageURL(contentImages[0], 'preview');
     }
   }
 

--- a/src/client/helpers/__tests__/postHelpers.js
+++ b/src/client/helpers/__tests__/postHelpers.js
@@ -1,4 +1,4 @@
-import { getAppData } from '../postHelpers';
+import { getAppData, getContentImages } from '../postHelpers';
 
 describe('getAppData', () => {
   it('should return an empty object when post does not contain an app', () => {
@@ -29,5 +29,65 @@ describe('getAppData', () => {
   it('should handle more app parameters without failing, eg. busy/1.2/other', () => {
     const post = { json_metadata: { app: 'busy/1.2.3/something' } };
     expect(getAppData(post)).toEqual({ appName: 'Busy', version: '1.2.3' });
+  });
+});
+
+describe('getContentImages', () => {
+  it('should return empty array if no images are found', () => {
+    const expected = [];
+    const actual = getContentImages('Hello World');
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return images array', () => {
+    const content = `
+Hello World!
+
+Before:
+![image](https://user-images.githubusercontent.com/1968722/41253250-0a6d2ece-6dc0-11e8-981a-a1d1a1c0ecec.png)
+
+After:
+![image](https://user-images.githubusercontent.com/1968722/41253262-1056e3f2-6dc0-11e8-8cfb-7cca34f41e86.png)
+
+Bye!
+    `;
+
+    const expected = [
+      'https://user-images.githubusercontent.com/1968722/41253250-0a6d2ece-6dc0-11e8-981a-a1d1a1c0ecec.png',
+      'https://user-images.githubusercontent.com/1968722/41253262-1056e3f2-6dc0-11e8-8cfb-7cca34f41e86.png',
+    ];
+    const actual = getContentImages(content);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return empty array if no images are found with parsed body', () => {
+    const expected = [];
+    const actual = getContentImages('<b>Hello</b>', true);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return images array', () => {
+    const content = `
+Hello World!
+
+Before:
+<img src="https://user-images.githubusercontent.com/1968722/41253250-0a6d2ece-6dc0-11e8-981a-a1d1a1c0ecec.png" />
+
+After:
+<img src="https://user-images.githubusercontent.com/1968722/41253262-1056e3f2-6dc0-11e8-8cfb-7cca34f41e86.png" />
+
+Bye!
+    `;
+
+    const expected = [
+      'https://user-images.githubusercontent.com/1968722/41253250-0a6d2ece-6dc0-11e8-981a-a1d1a1c0ecec.png',
+      'https://user-images.githubusercontent.com/1968722/41253262-1056e3f2-6dc0-11e8-8cfb-7cca34f41e86.png',
+    ];
+    const actual = getContentImages(content);
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/src/client/helpers/postHelpers.js
+++ b/src/client/helpers/postHelpers.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import { getHtml } from '../components/Story/Body';
+import { extractImageTags } from './parser';
 import { categoryRegex } from './regexHelpers';
 import { jsonParse } from './formatter';
 import DMCA from '../../common/constants/dmca.json';
@@ -53,5 +55,13 @@ export const isBannedPost = post => {
 
   return _.includes(bannedAuthors, post.author) || _.includes(bannedPosts, postURL);
 };
+
+export function getContentImages(content, parsed = false) {
+  const parsedBody = parsed ? content : getHtml(content, {}, 'text');
+
+  return extractImageTags(parsedBody).map(tag =>
+    tag.src.replace('https://steemitimages.com/0x0/', ''),
+  );
+}
 
 export default null;

--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -9,7 +9,8 @@ import { injectIntl } from 'react-intl';
 import uuidv4 from 'uuid/v4';
 import { getHtml } from '../../components/Story/Body';
 import improve from '../../helpers/improve';
-import { extractImageTags, extractLinks } from '../../helpers/parser';
+import { extractLinks } from '../../helpers/parser';
+import { getContentImages } from '../../helpers/postHelpers';
 import { rewardsValues } from '../../../common/constants/rewards';
 import LastDraftsContainer from './LastDraftsContainer';
 import DeleteDraftModal from './DeleteDraftModal';
@@ -205,9 +206,7 @@ class Write extends React.Component {
 
     const parsedBody = getHtml(postBody, {}, 'text');
 
-    const images = extractImageTags(parsedBody).map(tag =>
-      tag.src.replace('https://steemitimages.com/0x0/', ''),
-    );
+    const images = getContentImages(parsedBody, true);
     const links = extractLinks(parsedBody);
 
     if (data.title && !this.permlink) {


### PR DESCRIPTION
Fixes #1953 

### Changes

* Extract `getContentImages`.
* Use `getContentImages` globally for extracting images.

### Test plan

* [x] Go to: https://busy-master-pr-1962.herokuapp.com/trending/dlive
* [x] Image previews should work.