### PR TITLE
fix: filter out deleted posts

### DIFF
--- a/src/client/feed/feedActions.js
+++ b/src/client/feed/feedActions.js
@@ -193,7 +193,9 @@ export const getBookmarks = () => (dispatch, getState, { steemAPI }) => {
 
   dispatch({
     type: GET_BOOKMARKS.ACTION,
-    payload: getBookmarksData(bookmarks, steemAPI),
+    payload: getBookmarksData(bookmarks, steemAPI).then(posts =>
+      posts.filter(post => post.id !== 0),
+    ),
     meta: {
       sortBy: 'bookmarks',
       category: 'all',


### PR DESCRIPTION
Fixes #1959 

### Changes

* filter out deleted posts

### Test plan

* [x] Go to: https://busy.org/bookmarks
* [x] Deleted post should be visible.
* [x] Go to: http://localhost:3000/bookmarks
* [x] Deleted post shouldn't be visible.

### Demo

Before:
![image](https://user-images.githubusercontent.com/1968722/41253250-0a6d2ece-6dc0-11e8-981a-a1d1a1c0ecec.png)

After:
![image](https://user-images.githubusercontent.com/1968722/41253262-1056e3f2-6dc0-11e8-8cfb-7cca34f41e86.png)

