### PR TITLE
fix: disable textarea transitions

### DIFF
--- a/src/client/styles/common.less
+++ b/src/client/styles/common.less
@@ -46,6 +46,10 @@ a:focus {
   z-index: @ant-layout-header-z-index !important;
 }
 
+textarea.ant-input {
+  transition: none;
+}
+
 .ant-popover {
   z-index: @ant-popover-mobile-z-index !important;
 


### PR DESCRIPTION
Fixes #1944 

There is compatibility issue on FF that adds transition to height change, which is not desired. This disabled this behaviour.

### Changes

* Disable transitions on textarea

### Test plan

* [x] Go to editor on FF: https://busy-master-pr-1983.herokuapp.com/editor
* [x] Try dragging bottom right corner of input and resize it.
* [x] Resizing should be instant.
