### PR TITLE
fix: SBD price in Transfer modal

### DIFF
--- a/src/client/wallet/Transfer.js
+++ b/src/client/wallet/Transfer.js
@@ -72,7 +72,7 @@ export default class Transfer extends React.Component {
   componentDidMount() {
     const { cryptosPriceHistory } = this.props;
     const currentSteemRate = _.get(cryptosPriceHistory, 'STEEM.priceDetails.currentUSDPrice', null);
-    const currentSBDRate = _.get(cryptosPriceHistory, 'SBD.priceDetails.currentUSDPrice', null);
+    const currentSBDRate = _.get(cryptosPriceHistory, 'SBD*.priceDetails.currentUSDPrice', null);
 
     if (_.isNull(currentSteemRate)) {
       this.props.getCryptoPriceHistory(STEEM.symbol);
@@ -102,7 +102,7 @@ export default class Transfer extends React.Component {
     const { cryptosPriceHistory, intl } = this.props;
     const { currency, oldAmount } = this.state;
     const currentSteemRate = _.get(cryptosPriceHistory, 'STEEM.priceDetails.currentUSDPrice', null);
-    const currentSBDRate = _.get(cryptosPriceHistory, 'SBD.priceDetails.currentUSDPrice', null);
+    const currentSBDRate = _.get(cryptosPriceHistory, 'SBD*.priceDetails.currentUSDPrice', null);
     const steemRateLoading = _.isNull(currentSteemRate) || _.isNull(currentSBDRate);
     const parsedAmount = parseFloat(oldAmount);
     const invalidAmount = parsedAmount <= 0 || _.isNaN(parsedAmount);


### PR DESCRIPTION
Fixes #1924 

### Changes

* Use `SBD*` price.

### Test plan

* [ ] Go to: http://localhost:3000/@virus707/transfers
* [ ] Click on transfer button
* [ ] Type some amount
* [ ] Estimated value should appear.

### Demo

![image](https://user-images.githubusercontent.com/1968722/41767603-690d540c-760a-11e8-8c5a-77128e6bed2f.png)
