### PR TITLE
fix: no comments indicator

### DIFF
--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -248,7 +248,7 @@ class Comments extends React.Component {
           />
         )}
         {loading && <Loading />}
-        {parentPost.children === 0 && (
+        {commentsToRender.length === 0 && (
           <div className="Comments__empty">
             <FormattedMessage id="empty_comments" defaultMessage="There are no comments yet." />
           </div>


### PR DESCRIPTION
Fixes #2000

### Changes

* Compare real number of comments.

### Test plan

* [x] Create new post.
* [x] There should be `No comments` message.
* [x] Add new comment.
* [x] There shouldn't be `No comments` message.