### PR TITLE
fix: unsaving posts

### DIFF
--- a/src/client/feed/feedReducer.js
+++ b/src/client/feed/feedReducer.js
@@ -23,8 +23,9 @@ const feedIdsList = (state = [], action) => {
     case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_REPLIES.SUCCESS:
     case feedTypes.GET_MORE_REPLIES.SUCCESS:
-    case feedTypes.GET_BOOKMARKS.SUCCESS:
       return [...state, ...action.payload.map(post => post.id)];
+    case feedTypes.GET_BOOKMARKS.SUCCESS:
+      return action.payload.map(post => post.id);
     default:
       return state;
   }
@@ -146,7 +147,7 @@ const feed = (state = initialState, action) => {
           ...state.bookmarks,
           all: {
             ...state.bookmarks.all,
-            list: state.bookmarks.all.list.filter(item => item !== action.payload),
+            list: state.bookmarks.all.list.filter(item => item !== action.meta.id),
           },
         },
       };


### PR DESCRIPTION
Fixes #1997

### Changes

* Properly filter out bookmarks after toggling.
* Don't append old bookmarks on load.

### Test plan

* [x] Save post.
* [x] Go to http://localhost:3000/bookmarks
* [x] Unsave it.
* [x] It should disappear.

