### PR TITLE
fix: remove additional catch on getFollowing action

### DIFF
--- a/src/client/user/userActions.js
+++ b/src/client/user/userActions.js
@@ -67,7 +67,7 @@ export const getFollowing = username => (dispatch, getState) => {
     type: GET_FOLLOWING,
     meta: targetUsername,
     payload: {
-      promise: getAllFollowing(targetUsername).catch(() => dispatch({ type: GET_FOLLOWING_ERROR })),
+      promise: getAllFollowing(targetUsername),
     },
   });
 };


### PR DESCRIPTION
Fixes #2008 

### Changes

* Remove additional catch from promise (it should be handled by promise-middleware)
