### PR TITLE
fix: update ReputationTag props

### DIFF
--- a/src/client/components/ReputationTag.js
+++ b/src/client/components/ReputationTag.js
@@ -22,7 +22,7 @@ function ReputationTag({ intl, reputation }) {
 
 ReputationTag.propTypes = {
   intl: PropTypes.shape().isRequired,
-  reputation: PropTypes.string.isRequired,
+  reputation: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 
 export default injectIntl(ReputationTag);

--- a/src/client/stories/index.js
+++ b/src/client/stories/index.js
@@ -1,13 +1,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { IntlProvider } from 'react-intl';
+import translations from '../locales/default.json';
 import Action from '../components/Button/Action';
 import Avatar from '../components/Avatar';
 import BTooltip from '../components/BTooltip';
+import ReputationTag from '../components/ReputationTag';
 import Loading from '../components/Icon/Loading';
 import SidebarWidget from '../components/Sidebar/SidebarWidget';
 import '../styles/base.less';
 
+const IntlDecorator = storyFn => (
+  <IntlProvider locale="en" messages={translations}>
+    {storyFn()}
+  </IntlProvider>
+);
 const DefaultDecorator = storyFn => <div style={{ padding: 16 }}>{storyFn()}</div>;
 const CenterDecorator = storyFn => (
   <div
@@ -55,6 +63,11 @@ storiesOf('Avatar', module)
 storiesOf('BTooltip', module)
   .addDecorator(CenterDecorator)
   .add('default', () => <BTooltip title="This is tooltip">Hover me</BTooltip>);
+
+storiesOf('ReputationTag', module)
+  .addDecorator(IntlDecorator)
+  .addDecorator(CenterDecorator)
+  .add('default', () => <ReputationTag reputation="198532625245566" />);
 
 storiesOf('Loading', module)
   .addDecorator(DefaultDecorator)


### PR DESCRIPTION
Fixes #2009 

### Changes

* update ReputationTag props
* Add [story for ReputationTag](https://deploy-preview-2011--peaceful-feynman-099c7f.netlify.com/?selectedKind=ReputationTag&selectedStory=default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
