### PR TITLE
refactor: use ReputationTag on Discover page

### DIFF
--- a/src/client/discover/Discover.less
+++ b/src/client/discover/Discover.less
@@ -25,6 +25,10 @@
   }
 
   &__user {
+    &__name {
+      margin-right: 8px;
+    }
+
     &__content {
       font-weight: 500;
       display: flex;
@@ -47,15 +51,6 @@
       text-align: left;
       word-break: break-word;
       width: 100%;
-
-      .ant-tag {
-        margin-left: 8px;
-      }
-
-      .ant-tag-text {
-        font-weight: bold;
-        font-size: 12px;
-      }
 
       &__header {
         display: flex;

--- a/src/client/discover/DiscoverUser.js
+++ b/src/client/discover/DiscoverUser.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import urlParse from 'url-parse';
 import { Link } from 'react-router-dom';
-import { Tag } from 'antd';
-import formatter from '../helpers/steemitFormatter';
+import ReputationTag from '../components/ReputationTag';
 import Avatar from '../components/Avatar';
 import FollowButton from '../widgets/FollowButton';
 
@@ -15,7 +14,6 @@ const DiscoverUser = ({ user }) => {
   const location = userProfile.location;
   const name = userProfile.name;
   const about = userProfile.about;
-  const reputation = formatter.reputation(user.reputation);
   let website = userProfile.website;
 
   if (website && website.indexOf('http://') === -1 && website.indexOf('https://') === -1) {
@@ -42,8 +40,8 @@ const DiscoverUser = ({ user }) => {
                 <span className="Discover__user__name">
                   <span className="username">{name || user.name}</span>
                 </span>
+                <ReputationTag reputation={user.reputation} />
               </Link>
-              <Tag>{reputation}</Tag>
               <div className="Discover__user__follow">
                 <FollowButton username={user.name} />
               </div>


### PR DESCRIPTION
Fixes #2006 

### Changes

* Use `ReputationTag` on `Discover` page.

### Test plan

* [x] Go to: http://localhost:3000/discover
* [x] Reputation tag should have tooltip.
* [x] Clicking reputation tag should take you to user's profile.

### Demo

![image](https://user-images.githubusercontent.com/1968722/41905092-6a9e9f1e-793a-11e8-898b-d5f835d0e659.png)
