### PR TITLE
fix: display payout indicator if value will round up to 0.01

### DIFF
--- a/src/client/components/CommentFooter/Buttons.js
+++ b/src/client/components/CommentFooter/Buttons.js
@@ -230,7 +230,7 @@ class Buttons extends React.Component {
             </BTooltip>
           </span>
         )}
-        {payoutValue >= 0.05 && (
+        {payoutValue >= 0.005 && (
           <React.Fragment>
             <span className="CommentFooter__bullet" />
             <span className="CommentFooter__payout">

--- a/src/client/components/CommentFooter/Buttons.js
+++ b/src/client/components/CommentFooter/Buttons.js
@@ -230,7 +230,7 @@ class Buttons extends React.Component {
             </BTooltip>
           </span>
         )}
-        {payoutValue >= 0.01 && (
+        {payoutValue >= 0.05 && (
           <React.Fragment>
             <span className="CommentFooter__bullet" />
             <span className="CommentFooter__payout">

--- a/src/client/components/StoryFooter/Payout.js
+++ b/src/client/components/StoryFooter/Payout.js
@@ -13,7 +13,7 @@ const Payout = ({ intl, post }) => {
   const payoutValue = payout.cashoutInTime ? payout.potentialPayout : payout.pastPayouts;
 
   return (
-    payoutValue > 0.01 && (
+    payoutValue >= 0.05 && (
       <span className="Payout">
         <BTooltip title={<PayoutDetail post={post} />}>
           <span

--- a/src/client/components/StoryFooter/Payout.js
+++ b/src/client/components/StoryFooter/Payout.js
@@ -13,7 +13,7 @@ const Payout = ({ intl, post }) => {
   const payoutValue = payout.cashoutInTime ? payout.potentialPayout : payout.pastPayouts;
 
   return (
-    payoutValue >= 0.05 && (
+    payoutValue >= 0.005 && (
       <span className="Payout">
         <BTooltip title={<PayoutDetail post={post} />}>
           <span


### PR DESCRIPTION
Fixes #2018 

### Changes

Summary of changes you made.

* Display vote value If it will round up to 0.01 or more.

### Test plan

You would need to find a post that has rewards between 0.05 and 0.01 $ in rewards, which I couldn't find.

https://busy-master-pr-2024.herokuapp.com/@steemitblog/blockchain-update-3-hardfork-20-and-release-19-4-appbase-statsd-and-rocksdb#@tangerinetravels/re-steemitblog-blockchain-update-3-hardfork-20-and-release-19-4-appbase-statsd-and-rocksdb-20180627t210544220z
