### PR TITLE
fix: loading more feed content

### DIFF
--- a/src/client/feed/feedReducer.js
+++ b/src/client/feed/feedReducer.js
@@ -28,8 +28,8 @@ const feedIdsList = (state = [], action) => {
     case feedTypes.GET_REPLIES.SUCCESS:
     case feedTypes.GET_BOOKMARKS.SUCCESS:
       return action.payload.map(post => post.id);
-    case feedTypes.GET_MORE_FEED_CONTENT:
-    case feedTypes.GET_MORE_USER_COMMENTS:
+    case feedTypes.GET_MORE_FEED_CONTENT.SUCCESS:
+    case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_MORE_REPLIES.SUCCESS:
       return _.uniq([...state, ...action.payload.map(post => post.id)]);
     default:


### PR DESCRIPTION
Fixes #2027 

### Changes

* Fix action types in feedReducer.

### Test plan

* [x] Go to any feed and scroll down to see more posts. https://busy-master-pr-2028.herokuapp.com/trending/steemit
* [x] New posts should be loaded, only 1 request should be made.
