### PR TITLE
update BBackTop logic

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -218,7 +218,7 @@ export default class Wrapper extends React.PureComponent {
               <Transfer />
               <PowerUpOrDown />
               <NotificationPopup />
-              <BBackTop />
+              <BBackTop className="primary-modal" />
             </div>
           </Layout>
         </LocaleProvider>

--- a/src/client/components/BBackTop.js
+++ b/src/client/components/BBackTop.js
@@ -4,81 +4,28 @@ import { BackTop } from 'antd';
 import classNames from 'classnames';
 import './BBackTop.less';
 
-class BBackTop extends React.Component {
-  static propTypes = {
-    isModal: PropTypes.bool,
-    target: PropTypes.func,
-    toggleHeight: PropTypes.number,
-  };
-
-  static defaultProps = {
-    isModal: false,
-    target: undefined,
-    toggleHeight: 100,
-  };
-
-  static getDefaultTarget() {
-    return window;
-  }
-
-  static getScroll(target) {
-    if (typeof window === 'undefined') return 0;
-
-    return target === window ? target.pageYOffset : target.scrollTop;
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      visible: false,
-    };
-  }
-
-  componentDidMount() {
-    this.previousScroll = 0;
-    this.scrollEvent = this.getTarget().addEventListener('scroll', this.handleScroll);
-  }
-
-  componentWillUnmount() {
-    if (this.scrollEvent) this.scrollEvent.remove();
-  }
-
-  getTarget = () => (this.props.target || BBackTop.getDefaultTarget)();
-
-  handleScroll = () => {
-    const currentScroll = BBackTop.getScroll(this.getTarget());
-    if (currentScroll === 0) {
-      this.previousScroll = 0;
-      return;
-    }
-
-    const diff = currentScroll - this.previousScroll;
-    if (diff > 0) {
-      this.previousScroll = currentScroll;
-      this.setState({ visible: false });
-    } else if (diff < -this.props.toggleHeight) {
-      this.setState({ visible: true });
-    }
-  };
-
-  render() {
-    const { isModal, toggleHeight, ...otherProps } = this.props;
-    return (
-      this.state.visible && (
-        <div className="BBackTop">
-          <div
-            className={classNames('BBackTop__container', {
-              'BBackTop__container--shifted': this.props.isModal,
-            })}
-          >
-            <BackTop className="BBackTop_button" {...otherProps}>
-              <i className="iconfont icon-back-top" />
-            </BackTop>
-          </div>
-        </div>
-      )
-    );
-  }
+export default function BBackTop({ className, isModal, ...otherProps }) {
+  return (
+    <div className="BBackTop">
+      <div
+        className={classNames(className, 'BBackTop__container', {
+          'BBackTop__container--shifted': isModal,
+        })}
+      >
+        <BackTop className="BBackTop_button" {...otherProps}>
+          <i className="iconfont icon-back-top" />
+        </BackTop>
+      </div>
+    </div>
+  );
 }
 
-export default BBackTop;
+BBackTop.propTypes = {
+  className: PropTypes.string,
+  isModal: PropTypes.bool,
+};
+
+BBackTop.defaultProps = {
+  className: '',
+  isModal: false,
+};

--- a/src/client/post/PostModal.js
+++ b/src/client/post/PostModal.js
@@ -50,12 +50,14 @@ class PostModal extends React.Component {
   }
 
   componentDidMount() {
-    if (document) {
+    if (typeof document !== 'undefined') {
       const modalContents = document.getElementsByClassName('ant-modal-wrap');
       const modalContentElement = _.get(modalContents, 0);
       if (modalContentElement) {
         modalContentElement.scrollTop = 0;
       }
+
+      document.body.classList.add('post-modal');
     }
 
     const { currentShownPost } = this.props;
@@ -64,6 +66,10 @@ class PostModal extends React.Component {
   }
 
   componentWillUnmount() {
+    if (typeof document !== 'undefined') {
+      document.body.classList.remove('post-modal');
+    }
+
     this.props.hidePostModal();
   }
 

--- a/src/client/styles/common.less
+++ b/src/client/styles/common.less
@@ -82,6 +82,10 @@ body.white-bg .ant-tooltip {
   z-index: @ant-modal-tooltip-z-index !important;
 }
 
+body.post-modal .primary-modal {
+  display: none;
+}
+
 .ant-tooltip {
   z-index: 1060;
 


### PR DESCRIPTION
Fixes #2023 

### Changes

Current BBackTop logic seems to complicated and it might be confusing for users. Common way back-to-top buttons work is that they show when scrolled below certain threshold. This makes ours work the same way (default logic that BackTop from antd has) to prevent confusion.

* Change BBackTop logic.
* Hide primary BBackTop in post modal (#2023)

### Test plan

* [x] Scroll down in the feed.
* [x] BackTop button should show up.
* [x] Open the post in modal.
* [x] Previous BackTop button should disappear.
* [x] Scroll down.
* [x] New BackTop button should show up.

