### PR TITLE
Fix activity formatting on unfamiliar custom json operations (#1909)

### DIFF
--- a/src/client/activity/UserActionContents.js
+++ b/src/client/activity/UserActionContents.js
@@ -4,7 +4,16 @@ import _ from 'lodash';
 import * as accountHistory from '../../common/constants/accountHistory';
 
 const UserActionContents = ({ actionType, actionDetails }) => {
-  if (_.includes(accountHistory.PARSED_PROPERTIES, actionType)) {
+  if (actionType === accountHistory.CUSTOM_JSON) {
+    // Special case: Follow, Unfollow, Reblog, Mute operations are
+    // a part of custom json operations with actionDetails.id as "follow".
+    // We have a parser for these ops, however we cannot parse
+    // every custom json since it's flexible and there is no
+    // standard for the structure of custom_json ops.
+    if (_.includes(accountHistory.PARSED_CUSTOM_JSON_IDS, actionDetails.id)) {
+      return null;
+    }
+  } else if (_.includes(accountHistory.PARSED_PROPERTIES, actionType)) {
     return null;
   }
 

--- a/src/client/activity/UserActionIcon.js
+++ b/src/client/activity/UserActionIcon.js
@@ -34,6 +34,9 @@ class UserActionIcon extends React.Component {
         const customActionType = actionJSON[0];
         const customActionDetails = actionJSON[1];
 
+        if (!_.includes(accountHistoryConstants.PARSED_CUSTOM_JSON_IDS, actionDetails.id)) {
+          return 'icon-document';
+        }
         if (
           customActionType === accountHistoryConstants.REBLOG &&
           currentUsername === customActionDetails.account

--- a/src/client/activity/UserActionMessage.js
+++ b/src/client/activity/UserActionMessage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Link } from 'react-router-dom';
+import _ from 'lodash';
 import formatter from '../helpers/steemitFormatter';
 import * as accountHistoryConstants from '../../common/constants/accountHistory';
 import VoteActionMessage from './VoteActionMessage';
@@ -17,6 +18,10 @@ class UserActionMessage extends React.Component {
     totalVestingFundSteem: PropTypes.string.isRequired,
     currentUsername: PropTypes.string.isRequired,
   };
+
+  static renderDefault(actionType) {
+    return <FormattedMessage id={actionType} defaultMessage={actionType} />;
+  }
 
   renderFormattedMessage() {
     const {
@@ -89,6 +94,9 @@ class UserActionMessage extends React.Component {
           />
         );
       case accountHistoryConstants.CUSTOM_JSON:
+        if (!_.includes(accountHistoryConstants.PARSED_CUSTOM_JSON_IDS, actionDetails.id)) {
+          return UserActionMessage.renderDefault(actionType);
+        }
         return <CustomJSONMessage actionDetails={actionDetails} />;
       case accountHistoryConstants.ACCOUNT_UPDATE:
         return <FormattedMessage id="account_updated" defaultMessage="Account Updated" />;
@@ -184,7 +192,7 @@ class UserActionMessage extends React.Component {
           />
         );
       default:
-        return <FormattedMessage id={actionType} defaultMessage={actionType} />;
+        return UserActionMessage.renderDefault(actionType);
     }
   }
   render() {

--- a/src/common/constants/accountHistory.js
+++ b/src/common/constants/accountHistory.js
@@ -12,6 +12,9 @@ export const AUTHOR_REWARD = 'author_reward';
 export const ACCOUNT_WITNESS_VOTE = 'account_witness_vote';
 export const FILL_VESTING_WITHDRAW = 'fill_vesting_withdraw';
 
+// Supported Custom JSON Type IDs
+export const ID_FOLLOW = 'follow';
+
 // Wallet Action Types
 export const TRANSFER = 'transfer';
 export const TRANSFER_TO_VESTING = 'transfer_to_vesting';
@@ -55,3 +58,5 @@ export const PARSED_PROPERTIES = [
   ACCOUNT_WITNESS_VOTE,
   FILL_VESTING_WITHDRAW,
 ];
+
+export const PARSED_CUSTOM_JSON_IDS = [ID_FOLLOW];


### PR DESCRIPTION
Fixes #1909 

Continuation of https://github.com/busyorg/busy/pull/2015.

- Added a new icon for unfamiliar custom jsons.
- Re-created the PR with the ```develop``` target since the convention is changed. And I wasn't able to update the base branch for the old pull request. 

Now it looks like this:

<img width="573" alt="screen shot 2018-07-05 at 12 01 05 am" src="https://user-images.githubusercontent.com/72460/42294315-97bc5572-7fe8-11e8-9dbe-f53628b87c2a.png">

Not sure about the icon selection, I can change it if there is a better fit.