### PR TITLE
fix: refresh login based on loaded, not authenticated prop

### DIFF
--- a/src/client/auth/authActions.js
+++ b/src/client/auth/authActions.js
@@ -1,6 +1,6 @@
 import Cookie from 'js-cookie';
 import { createAction } from 'redux-actions';
-import { getAuthenticatedUserName, getIsAuthenticated } from '../reducers';
+import { getAuthenticatedUserName, getIsAuthenticated, getIsLoaded } from '../reducers';
 import { createAsyncActionType } from '../helpers/stateHelpers';
 import { addNewNotification } from '../app/appActions';
 import { getFollowing } from '../user/userActions';
@@ -24,9 +24,11 @@ export const BUSY_LOGIN = createAsyncActionType('@auth/BUSY_LOGIN');
 const loginError = createAction(LOGIN_ERROR);
 
 export const login = () => (dispatch, getState, { steemConnectAPI }) => {
+  const state = getState();
+
   let promise = Promise.resolve(null);
 
-  if (getIsAuthenticated(getState())) {
+  if (getIsLoaded(state)) {
     promise = Promise.resolve(null);
   } else if (!steemConnectAPI.options.accessToken) {
     promise = Promise.reject(new Error('There is not accessToken present'));
@@ -40,7 +42,7 @@ export const login = () => (dispatch, getState, { steemConnectAPI }) => {
       promise,
     },
     meta: {
-      refresh: getIsAuthenticated(getState()),
+      refresh: getIsLoaded(state),
     },
   }).catch(() => dispatch(loginError()));
 };


### PR DESCRIPTION
Fixes #2020

### Changes

Previously action determined if we are refreshing or logging in, based on authenticated prop, which caused another login try when not authenticated.

* refresh login based on loaded, not authenticated prop

### Test plan

* [x] Make sure to be logged out.
* [x] Go to: https://busy-develop-pr-2042.herokuapp.com/
* [x] SSR should work and feed shouldn't reload.
* [x] Go to: https://busy-develop-pr-2042.herokuapp.com/trending/steemit
* [x] SSR should work and feed shouldn't reload.

