### PR TITLE
fix: add UPVOTE_LOCKOUT error fingerprint

### DIFF
--- a/src/client/helpers/__tests__/errorMiddleware.js
+++ b/src/client/helpers/__tests__/errorMiddleware.js
@@ -44,6 +44,10 @@ describe('parseBlockChainError', () => {
     expected =
       'Your voting power is too small, please accumulate more voting power or steem power.';
     expect(actual).toEqual(expected);
+
+    actual = parseBlockChainError('Cannot increase payout within last twelve hours before payout.');
+    expected = "You can't increase payout within last twelve hours before payout.";
+    expect(actual).toEqual(expected);
   });
 
   it('should extract message from unknown error', () => {

--- a/src/common/constants/errors.js
+++ b/src/common/constants/errors.js
@@ -27,4 +27,8 @@ export default {
     fingerprint: 'abs_rshares > STEEM_VOTE_DUST_THRESHOLD',
     message: 'Your voting power is too small, please accumulate more voting power or steem power.',
   },
+  UPVOTE_LOCKOUT: {
+    fingerprint: 'Cannot increase payout within last twelve hours before payout.',
+    message: "You can't increase payout within last twelve hours before payout.",
+  },
 };


### PR DESCRIPTION
Fixes #2038 

### Changes

* add UPVOTE_LOCKOUT error fingerprint

### Test plan

It would require to find a post almost 7 days old and to make an upvote that will manage to change rshares of the post. I failed to find such post - added test should suffice though.