### PR TITLE
fix: subtract delegated_vesting_shares from available shares

### DIFF
--- a/src/client/wallet/PowerUpOrDown.js
+++ b/src/client/wallet/PowerUpOrDown.js
@@ -59,7 +59,11 @@ export default class PowerUpOrDown extends React.Component {
     const { user, down, totalVestingShares, totalVestingFundSteem } = this.props;
 
     return down
-      ? formatter.vestToSteem(user.vesting_shares, totalVestingShares, totalVestingFundSteem)
+      ? formatter.vestToSteem(
+          parseFloat(user.vesting_shares) - parseFloat(user.delegated_vesting_shares),
+          totalVestingShares,
+          totalVestingFundSteem,
+        )
       : parseFloat(user.balance);
   };
 


### PR DESCRIPTION
Fixes #2046 

### Changes

* Subtract delegated shares from user shares (maximum what user can power down).

### Test plan

* [x] Login as hellosteem.
* [x] Go to: https://busy-develop-pr-2047.herokuapp.com/@hellosteem/transfers
* [x] Click Power down
* [x] User should be able to power down for 1.961 SP at most.
