### PR TITLE
fix: always set current images, links, users and tags

### DIFF
--- a/src/client/post/Write/Write.js
+++ b/src/client/post/Write/Write.js
@@ -232,18 +232,10 @@ class Write extends React.Component {
       };
     }
 
-    if (tags.length) {
-      metaData.tags = tags;
-    }
-    if (users.length) {
-      metaData.users = users;
-    }
-    if (links.length) {
-      metaData.links = links.slice(0, 10);
-    }
-    if (images.length) {
-      metaData.image = images;
-    }
+    metaData.tags = tags;
+    metaData.users = users;
+    metaData.links = links.slice(0, 10);
+    metaData.image = images;
 
     data.parentPermlink = tags.length ? tags[0] : 'general';
     data.jsonMetadata = metaData;


### PR DESCRIPTION
Fixes #2022

### Changes

* always set current images, links, users and tags (they are always arrays).

### Test plan

Follow how to reproduce steps from the issue using this post as edited post:
https://busy-develop-pr-2048.herokuapp.com/@hellosteem/test-post-with-image

