### PR TITLE
feat: add create json metadata for comments

### DIFF
--- a/src/client/comments/commentsActions.js
+++ b/src/client/comments/commentsActions.js
@@ -1,9 +1,8 @@
 import { createAction } from 'redux-actions';
 import { createCommentPermlink, getBodyPatchIfSmaller } from '../vendor/steemitHelpers';
 import { notify } from '../app/Notification/notificationActions';
-import { jsonParse } from '../../client/helpers/formatter';
-
-const version = require('../../../package.json').version;
+import { jsonParse } from '../helpers/formatter';
+import { createPostMetadata } from '../helpers/postHelpers';
 
 export const GET_COMMENTS = 'GET_COMMENTS';
 export const GET_COMMENTS_START = 'GET_COMMENTS_START';
@@ -99,10 +98,11 @@ export const sendComment = (parentPost, body, isUpdating = false, originalCommen
     ? originalComment.permlink
     : createCommentPermlink(parentAuthor, parentPermlink);
 
-  const defaultJsonMetadata = { tags: [category], community: 'busy', app: `busy/${version}` };
-  const jsonMetadata = isUpdating
-    ? jsonParse(originalComment.json_metadata) || defaultJsonMetadata
-    : defaultJsonMetadata;
+  const jsonMetadata = createPostMetadata(
+    body,
+    [category],
+    isUpdating && jsonParse(originalComment.json_metadata),
+  );
 
   const newBody = isUpdating ? getBodyPatchIfSmaller(originalComment.body, body) : body;
 

--- a/src/client/helpers/parser.js
+++ b/src/client/helpers/parser.js
@@ -46,7 +46,7 @@ export function extractImageTags(body) {
 }
 
 export function extractLinks(body) {
-  return extract(body, hrefRegex);
+  return extract(body, hrefRegex).map(_.unescape);
 }
 
 export default null;

--- a/src/client/helpers/postHelpers.js
+++ b/src/client/helpers/postHelpers.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import { getHtml } from '../components/Story/Body';
-import { extractImageTags } from './parser';
+import { extractImageTags, extractLinks } from './parser';
 import { categoryRegex } from './regexHelpers';
 import { jsonParse } from './formatter';
 import DMCA from '../../common/constants/dmca.json';
 import whiteListedApps from './apps';
+
+const appVersion = require('../../../package.json').version;
 
 export const isPostDeleted = post => post.title === 'deleted' && post.body === 'deleted';
 
@@ -60,8 +62,42 @@ export function getContentImages(content, parsed = false) {
   const parsedBody = parsed ? content : getHtml(content, {}, 'text');
 
   return extractImageTags(parsedBody).map(tag =>
-    tag.src.replace('https://steemitimages.com/0x0/', ''),
+    _.unescape(tag.src.replace('https://steemitimages.com/0x0/', '')),
   );
 }
 
-export default null;
+export function createPostMetadata(body, tags, oldMetadata = {}) {
+  let metaData = {
+    community: 'busy',
+    app: `busy/${appVersion}`,
+    format: 'markdown',
+  };
+
+  metaData = {
+    ...oldMetadata,
+    ...metaData,
+  };
+
+  const users = [];
+  const userRegex = /@([a-zA-Z.0-9-]+)/g;
+  let matches;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((matches = userRegex.exec(body))) {
+    if (users.indexOf(matches[1]) === -1) {
+      users.push(matches[1]);
+    }
+  }
+
+  const parsedBody = getHtml(body, {}, 'text');
+
+  const images = getContentImages(parsedBody, true);
+  const links = extractLinks(parsedBody);
+
+  metaData.tags = tags;
+  metaData.users = users;
+  metaData.links = links.slice(0, 10);
+  metaData.image = images;
+
+  return metaData;
+}


### PR DESCRIPTION
Fixes #2045 

### Changes

* extract `createPostMetadata` helper.
* unescape links and images (they contain HTML entities after sanitizsation).
* add links, images, and mentions to comments.

### Test plan

* [x] Create new post with mentions, images, and links:
```
Links:
https://www.google.com/intl/pl_pl/about/?utm_source=google.com&utm_medium=referral&utm_campaign=hp-footer&fg=1

Mentions:
@sekhmet

![image.png](https://ipfs.busy.org/ipfs/Qmb7DDhcPZyt8vjvY9wjyFycaUSMTivAS9QbaSeRUvgccu)
```

* [x] This post should have those items included (verify on steemd)
* [x] Create comment with same content.
* [x] This comment should have those items included (verify on steemd)

