### PR TITLE
Show logged out message when saving draft

### DIFF
--- a/src/client/components/Story/Story.js
+++ b/src/client/components/Story/Story.js
@@ -1,7 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
+import {
+  injectIntl,
+  FormattedMessage,
+  FormattedRelative,
+  FormattedDate,
+  FormattedTime,
+} from 'react-intl';
 import { Link, withRouter } from 'react-router-dom';
 import { Tag } from 'antd';
 import formatter from '../../helpers/steemitFormatter';
@@ -25,10 +31,12 @@ import DMCARemovedMessage from './DMCARemovedMessage';
 import PostedFrom from './PostedFrom';
 import './Story.less';
 
+@injectIntl
 @withRouter
 @withAuthActions
 class Story extends React.Component {
   static propTypes = {
+    intl: PropTypes.shape().isRequired,
     user: PropTypes.shape().isRequired,
     post: PropTypes.shape().isRequired,
     postState: PropTypes.shape().isRequired,
@@ -143,7 +151,8 @@ class Story extends React.Component {
   }
 
   handleEditClick(post) {
-    if (post.depth === 0) return this.props.editPost(post);
+    const { intl } = this.props;
+    if (post.depth === 0) return this.props.editPost(post, intl);
     return this.props.push(`${post.url}-edit`);
   }
 

--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -353,5 +353,6 @@
   "hero_banner_title_3": "Earn rewards in Steem",
   "amount_currency": "{amount} {currency}",
   "save_draft_error": "Couldn't save this draft. Make sure you are connected to the internet and don't have too much drafts already",
+  "draft_save_auth_error": "Couldn't save this draft, because you are logged out. Please backup your post and log in again.",
   "version": "Version: {version}"
 }

--- a/src/client/post/PostContent.js
+++ b/src/client/post/PostContent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import _ from 'lodash';
@@ -34,6 +35,7 @@ import { jsonParse } from '../helpers/formatter';
 import StoryFull from '../components/Story/StoryFull';
 import DMCARemovedMessage from '../components/Story/DMCARemovedMessage';
 
+@injectIntl
 @connect(
   state => ({
     user: getAuthenticatedUser(state),
@@ -63,6 +65,7 @@ import DMCARemovedMessage from '../components/Story/DMCARemovedMessage';
 )
 class PostContent extends React.Component {
   static propTypes = {
+    intl: PropTypes.shape().isRequired,
     user: PropTypes.shape().isRequired,
     content: PropTypes.shape().isRequired,
     signature: PropTypes.string,
@@ -151,7 +154,8 @@ class PostContent extends React.Component {
   };
 
   handleEditClick = post => {
-    if (post.depth === 0) return this.props.editPost(post);
+    const { intl } = this.props;
+    if (post.depth === 0) return this.props.editPost(post, intl);
     this.props.push(`${post.url}-edit`);
     return Promise.resolve(null);
   };

--- a/src/client/post/PostContent.js
+++ b/src/client/post/PostContent.js
@@ -156,8 +156,7 @@ class PostContent extends React.Component {
   handleEditClick = post => {
     const { intl } = this.props;
     if (post.depth === 0) return this.props.editPost(post, intl);
-    this.props.push(`${post.url}-edit`);
-    return Promise.resolve(null);
+    return this.props.push(`${post.url}-edit`);
   };
 
   render() {


### PR DESCRIPTION
Fixes #1641

### Changes

* Always provide `intl` to saveDraft action to avoid cases of untranslated message.
* Detect `invalid_grant` message and show specific error message.

### Test plan

* [ ] Start writing new post.
* [ ] Log out in different tab.
* [ ] Type some more contents and wait for draft to save.
* [ ] Error message about being logged out should show up.
