### PR TITLE
Update draft types

### DIFF
--- a/src/client/components/Sidebar/LastDrafts.js
+++ b/src/client/components/Sidebar/LastDrafts.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedRelative } from 'react-intl';
 import { Link } from 'react-router-dom';
+import { draftType, draftArrayType } from '../../types/drafts';
 import Loading from '../../components/Icon/Loading';
 import './LastDrafts.less';
 import './SidebarContentBlock.less';
@@ -21,7 +22,7 @@ const Draft = ({ draft }) => (
   </div>
 );
 Draft.propTypes = {
-  draft: PropTypes.shape().isRequired,
+  draft: draftType.isRequired,
 };
 
 const LastDrafts = ({ drafts, loaded }) => {
@@ -55,7 +56,7 @@ const LastDrafts = ({ drafts, loaded }) => {
 };
 
 LastDrafts.propTypes = {
-  drafts: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string, title: PropTypes.string })),
+  drafts: draftArrayType,
   loaded: PropTypes.bool,
 };
 

--- a/src/client/post/Write/DraftRow.js
+++ b/src/client/post/Write/DraftRow.js
@@ -4,13 +4,14 @@ import _ from 'lodash';
 import { FormattedMessage, FormattedRelative } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Checkbox } from 'antd';
+import { draftType } from '../../types/drafts';
 import DeleteDraftModal from './DeleteDraftModal';
 import './DraftRow.less';
 
 class DraftRow extends React.Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
-    data: PropTypes.shape().isRequired,
+    draft: draftType.isRequired,
     selected: PropTypes.bool,
     onCheck: PropTypes.func,
   };
@@ -46,10 +47,10 @@ class DraftRow extends React.Component {
   }
 
   render() {
-    const { id, data, selected } = this.props;
-    const { lastUpdated } = data;
+    const { id, draft, selected } = this.props;
+    const { lastUpdated } = draft;
     const hasLastUpdated = !_.isUndefined(lastUpdated);
-    let { title = '', body = '' } = data;
+    let { title = '', body = '' } = draft;
     title = title.trim();
     body = body.replace(/\r?\n|\r|[\u200B-\u200D\uFEFF]/g, ' ').substring(0, 50);
     let draftTitle = title.length ? title : body;

--- a/src/client/post/Write/Drafts.js
+++ b/src/client/post/Write/Drafts.js
@@ -149,7 +149,7 @@ class Drafts extends React.Component {
               _.map(sortedDraftPosts, draft => (
                 <DraftRow
                   key={draft.id}
-                  data={draft}
+                  draft={draft}
                   id={draft.id}
                   selected={selectedDrafts.includes(draft.id)}
                   pending={pendingDrafts.includes(draft.id)}

--- a/src/client/types/drafts.js
+++ b/src/client/types/drafts.js
@@ -1,0 +1,10 @@
+import PropTypes from 'prop-types';
+
+export const draftType = PropTypes.shape({
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  lastUpdated: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  title: PropTypes.string,
+  body: PropTypes.string,
+});
+
+export const draftArrayType = PropTypes.arrayOf(draftType);


### PR DESCRIPTION
Fixes #2059 

### Changes

Draft type is used in many places so I extracted its types to its own file.

* Define stricter prop types.
* Rename `data` to `drafts` in `DraftRow` to make it more clear what it represents.

### Test plan

* [x] Run it locally (warnings only show on development build).
* [x] Go to editor - no warnings should be shown.
* [x] Go to Menu -> Drafts - no warnings should be shown.

