### PR TITLE
allow mixed line endings locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,5 +32,7 @@ module.exports = {
     ],
     'no-console': OFF,
     'global-require': OFF,
+    // Allow mixed linebreaks locally, but commit only LF.
+    'linebreak-style': process.env.CI ? ['error', 'unix'] : OFF,
   },
 };


### PR DESCRIPTION
This will allow any mix of LF and CRLF locally, but will fail on CI if CRLF are commited. This basically requires users to configure Git to commit LF (`core.autocrlf true`).