### PR TITLE
feat: display vote count if there is more than one of any vote

### DIFF
--- a/src/client/components/StoryFooter/Buttons.js
+++ b/src/client/components/StoryFooter/Buttons.js
@@ -309,7 +309,7 @@ export default class Buttons extends React.Component {
             )}
           </a>
         </BTooltip>
-        {upVotes.length > 0 && (
+        {post.active_votes.length > 0 && (
           <span
             className="Buttons__number Buttons__reactions-count"
             role="presentation"
@@ -318,7 +318,11 @@ export default class Buttons extends React.Component {
             <BTooltip
               title={
                 <div>
-                  {upVotesPreview}
+                  {upVotes.length > 0 ? (
+                    upVotesPreview
+                  ) : (
+                    <FormattedMessage id="no_likes" defaultMessage="No likes yet" />
+                  )}
                   {upVotesMore}
                 </div>
               }


### PR DESCRIPTION
Fixes #2068 

### Changes

* Display vote count if there is at least one vote.
* Display placeholder for tooltip if there are only downvotes.

### Test plan

* [x] Go to: https://busy-develop-pr-2072.herokuapp.com/@fastandcurious/test-post-for-special-characters
* [x] You should see upvote count next to like button (0).
* [x] Tooltip on that count should have message about no upvotes.
* [x] Clicking on that count should open modal with votes.

### Demo

![obraz](https://user-images.githubusercontent.com/1968722/42762499-cf1ce2c6-8910-11e8-9ef2-a1f11e8e8633.png)

