### PR TITLE
fix: don't display no comments message before comments loaded

### DIFF
--- a/src/client/comments/Comments.js
+++ b/src/client/comments/Comments.js
@@ -184,6 +184,7 @@ export default class Comments extends React.Component {
           username={this.props.username}
           pendingVotes={pendingVotes}
           loading={comments.isFetching}
+          loaded={comments.isLoaded}
           show={show}
           notify={this.props.notify}
           rewardFund={rewardFund}

--- a/src/client/comments/Comments.js
+++ b/src/client/comments/Comments.js
@@ -98,11 +98,7 @@ export default class Comments extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { post, show } = this.props;
 
-    if (
-      nextProps.show &&
-      nextProps.post.children !== 0 &&
-      (nextProps.post.id !== post.id || !show)
-    ) {
+    if (nextProps.show && (nextProps.post.id !== post.id || !show)) {
       this.props.getComments(nextProps.post.id);
     }
   }

--- a/src/client/comments/commentsReducer.js
+++ b/src/client/comments/commentsReducer.js
@@ -5,6 +5,7 @@ const initialState = {
   comments: {},
   pendingVotes: [],
   isFetching: false,
+  isLoaded: false,
 };
 
 const childrenById = (state = {}, action) => {
@@ -64,6 +65,18 @@ const isFetching = (state = initialState.isFetching, action) => {
   }
 };
 
+const isLoaded = (state = initialState.isLoaded, action) => {
+  switch (action.type) {
+    case commentsTypes.GET_COMMENTS_START:
+      return false;
+    case commentsTypes.GET_COMMENTS_SUCCESS:
+    case commentsTypes.GET_COMMENTS_ERROR:
+      return true;
+    default:
+      return state;
+  }
+};
+
 const comments = (state = initialState, action) => {
   switch (action.type) {
     case commentsTypes.GET_COMMENTS_START:
@@ -74,6 +87,7 @@ const comments = (state = initialState, action) => {
         comments: commentsData(state.comments, action),
         childrenById: childrenById(state.childrenById, action),
         isFetching: isFetching(state.isFetching, action),
+        isLoaded: isLoaded(state.isLoaded, action),
       };
     case commentsTypes.LIKE_COMMENT_START:
       return {

--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -18,6 +18,8 @@ class Comments extends React.Component {
     intl: PropTypes.shape().isRequired,
     user: PropTypes.shape().isRequired,
     authenticated: PropTypes.bool.isRequired,
+    loading: PropTypes.bool.isRequired,
+    loaded: PropTypes.bool.isRequired,
     username: PropTypes.string,
     parentPost: PropTypes.shape(),
     comments: PropTypes.shape(),
@@ -33,7 +35,6 @@ class Comments extends React.Component {
     defaultVotePercent: PropTypes.number.isRequired,
     rewriteLinks: PropTypes.bool,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
-    loading: PropTypes.bool,
     show: PropTypes.bool,
     notify: PropTypes.func,
     onLikeClick: PropTypes.func,
@@ -50,7 +51,6 @@ class Comments extends React.Component {
     pendingVotes: [],
     rewriteLinks: false,
     sliderMode: 'auto',
-    loading: false,
     show: false,
     notify: () => {},
     onLikeClick: () => {},
@@ -195,6 +195,7 @@ class Comments extends React.Component {
       rootLevelComments,
       commentsChildren,
       loading,
+      loaded,
       show,
       pendingVotes,
       onLikeClick,
@@ -248,12 +249,13 @@ class Comments extends React.Component {
           />
         )}
         {loading && <Loading />}
-        {commentsToRender.length === 0 && (
-          <div className="Comments__empty">
-            <FormattedMessage id="empty_comments" defaultMessage="There are no comments yet." />
-          </div>
-        )}
-        {!loading &&
+        {loaded &&
+          commentsToRender.length === 0 && (
+            <div className="Comments__empty">
+              <FormattedMessage id="empty_comments" defaultMessage="There are no comments yet." />
+            </div>
+          )}
+        {loaded &&
           show &&
           comments &&
           commentsToRender.map(comment => (


### PR DESCRIPTION
Fixes #2070 

### Changes

* Add `isLoaded` prop to comments.
* Call `getComments` for side effects even without comments.
* Display no comments indicator only if comments have been loaded.

### Test plan

* [x] Check post without comments: https://busy-develop-pr-2073.herokuapp.com/@hellosteem/testing-metadata
* [x] It should have `no comments` indicator.
* [x] Open post with comments: https://busy-develop-pr-2073.herokuapp.com/@fivestargroup/exclusive-five-star-entertainment-steeming-steemit-anthem-official-music-video-by-rest100
* [x] Scroll down to see comments.
* [x] `no comments` indicator should not be visible while loading comments (and after they has been loaded as well)
