### PR TITLE
always use 3 decimal points for transfer amount

### DIFF
--- a/src/client/wallet/Transfer.js
+++ b/src/client/wallet/Transfer.js
@@ -146,7 +146,7 @@ export default class Transfer extends React.Component {
       if (!errors) {
         const transferQuery = {
           to: values.to,
-          amount: `${values.amount} ${values.currency}`,
+          amount: `${parseFloat(values.amount).toFixed(3)} ${values.currency}`,
         };
         if (values.memo) transferQuery.memo = values.memo;
 


### PR DESCRIPTION
Fixes #2066 

### Changes

* always use 3 decimal points for transfer amount

### Test plan

* [ ] Go there: https://busy.org/@sekhmet/transfers and click on transfer
* [ ] Enter amount with 1 or 2 decimal points.
* [ ] Click on continue.
* [ ] On SteemConnect page in URL you should have 3 decimal points for amount.
