### PR TITLE
Feature/encrypted memo

### DIFF
--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -116,6 +116,8 @@
   "by": "By {username}",
   "memo": "Memo",
   "memo_placeholder": "Additional message to include in this payment (optional)",
+  "memo_exchange_error": "Memo is required when sending to an exchange.",
+  "memo_encryption_error": "Encrypted memos are not supported.",
   "power_up": "Power up",
   "power_down": "Power down",
   "message": "Message",

--- a/src/client/wallet/Transfer.js
+++ b/src/client/wallet/Transfer.js
@@ -185,7 +185,7 @@ export default class Transfer extends React.Component {
           }),
         ),
       ]);
-    } else if (value && value[0] === '#') {
+    } else if (value && value.trim()[0] === '#') {
       return callback([
         new Error(
           intl.formatMessage({

--- a/src/client/wallet/Transfer.js
+++ b/src/client/wallet/Transfer.js
@@ -175,18 +175,28 @@ export default class Transfer extends React.Component {
   validateMemo = (rule, value, callback) => {
     const { intl } = this.props;
     const recipientIsExchange = Transfer.exchangeRegex.test(this.props.form.getFieldValue('to'));
+
     if (recipientIsExchange && (!value || value === '')) {
-      callback([
+      return callback([
         new Error(
           intl.formatMessage({
-            id: 'memo_error_exchange',
+            id: 'memo_exchange_error',
             defaultMessage: 'Memo is required when sending to an exchange.',
           }),
         ),
       ]);
-    } else {
-      callback();
+    } else if (value && value[0] === '#') {
+      return callback([
+        new Error(
+          intl.formatMessage({
+            id: 'memo_encryption_error',
+            defaultMessage: 'Encrypted memos are not supported.',
+          }),
+        ),
+      ]);
     }
+
+    return callback();
   };
 
   validateUsername = (rule, value, callback) => {


### PR DESCRIPTION
Fixes #2076 

### Changes

* Add missing `memo_encryption_error` translation.
* Validate if user wants to encrypt a memo.

### Test plan

* [x] Go to: https://busy-develop-pr-2077.herokuapp.com/@hellosteem/transfers and click on Transfer
* [x] Type memo with `#` at the beginning.
* [x] Error message should show up.

### Demo

![obraz](https://user-images.githubusercontent.com/1968722/42815429-a030a4fe-89c7-11e8-99a4-cdfcb7c1800c.png)
