### PR TITLE
Allowed protocols

### DIFF
--- a/src/client/vendor/SanitizeConfig.js
+++ b/src/client/vendor/SanitizeConfig.js
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import URL from 'url-parse';
 import { ownUrl } from '../helpers/regexHelpers';
 import { knownDomains } from '../helpers/constants';
@@ -87,6 +88,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [], secureLink
     img: ['src', 'alt'],
     a: ['href', 'rel', 'target'],
   },
+  allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['byteball', 'bitcoin']),
   transformTags: {
     iframe: (tagName, attribs) => {
       const srcAtty = decodeURIComponent(attribs.src);

--- a/src/client/vendor/SanitizeConfig.js
+++ b/src/client/vendor/SanitizeConfig.js
@@ -170,7 +170,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [], secureLink
       const url = new URL(href);
       const hostname = url.hostname || 'localhost';
 
-      if (!hostname.match(ownUrl)) {
+      if (['https', 'http'].indexOf(url.protocol) || !hostname.match(ownUrl)) {
         attys.target = '_blank';
       }
 

--- a/src/client/vendor/steemitHtmlReady.js
+++ b/src/client/vendor/steemitHtmlReady.js
@@ -122,7 +122,7 @@ function link(state, child) {
     state.links.add(url);
     if (state.mutate) {
       // If this link is not relative, http, or https -- add https.
-      if (!/^\/(?!\/)|(https?:)?\/\//.test(url)) {
+      if (!/^[\w.-]+:(\/\/)?/.test(url)) {
         child.setAttribute('href', `https://${url}`);
       }
     }


### PR DESCRIPTION
Fixes #2084 

### Changes

* Properly detect missing protocol.
* Whitelist `byteball` and `bitcoin` protocol (sanitize-html doesn't support disabling this check yet, I submitted PR for this, but I'm not sure if it is desired behaviour).
* Mark non `https?` protocols as external.

### Test plan

Explain how to test changes you made.

* [x] Go to: https://busy-develop-pr-2092.herokuapp.com/@hellosteem/4jvpqd-test
* [x] It should have link pointing to `byteball:SDTTLBG347WV2LQJRTKM2E4XM37HBM65`

