### PR TITLE
Only show the editor when you explicitly visit /editor

### DIFF
--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -57,6 +57,7 @@ const routes = [
       {
         path: '/editor',
         component: Editor,
+        exact: true,
       },
       {
         path: '/settings',


### PR DESCRIPTION
Fixes #2096 

### Changes

* Only show the editor when you explicitly visit /editor

### Test plan

* [x] Visit this post https://busy.org/@east.autovote/editor-test
* [x] Click on the comment button
* [x] You should still be on the post page