### PR TITLE
add new permlinks to dmca.json

### DIFF
--- a/src/common/constants/dmca.json
+++ b/src/common/constants/dmca.json
@@ -19,6 +19,8 @@
     "doujinblog/180630rj226466-booljr1545",
     "doujinblog/180630rj220960-7brgs7iru2",
     "arabebtc/big-butt-wiggling",
-    "doujinblog/180701rj228604-9arcnnx5cr"
+    "doujinblog/180701rj228604-9arcnnx5cr",
+    "amitayboneh/this-is-why-cindicator-cnd-worth-5usd-20usd-the-full-pbc-review",
+    "jzeal/ripple-xrp-palm-beach-confidential-teeka-tiwari-s-article-and-breakdown"
   ]
 }


### PR DESCRIPTION
Fixes 
We got this DMCA takedown notice
```
Cloudflare received a DMCA copyright infringement complaint regarding: 

busy.org 
Below is the complaint we received: 

Reporter's Name: Mark Reyes 
Copyright Holder's Name: 
Reporter's Email Address: report@internetsecurities.org 
Reporter's Company Name: Internet Securities International 
Reporter's Telephone Number: 852 8199 0145 
Reporter's Address: Tsim Sha Tsui, Kowloon, Hong Kong HK 

Reported URLs: 

http://busy.org/@jzeal/ripple-xrp-palm-beach-confidential-teeka-tiwari-s-article-and-breakdown 
http://busy.org/@amitayboneh/this-is-why-cindicator-cnd-worth-5usd-20usd-the-full-pbc-review 
```
### Changes

Add url's to dmca.json