### PR TITLE
fix: rename id to post_id

### DIFF
--- a/src/client/comments/commentsActions.js
+++ b/src/client/comments/commentsActions.js
@@ -27,13 +27,13 @@ export const reloadExistingComment = createAction(RELOAD_EXISTING_COMMENT, undef
 const getRootCommentsList = apiRes =>
   Object.keys(apiRes.content)
     .filter(commentKey => apiRes.content[commentKey].depth === 1)
-    .map(commentKey => apiRes.content[commentKey].id);
+    .map(commentKey => apiRes.content[commentKey].post_id);
 
 const getCommentsChildrenLists = apiRes => {
   const listsById = {};
   Object.keys(apiRes.content).forEach(commentKey => {
-    listsById[apiRes.content[commentKey].id] = apiRes.content[commentKey].replies.map(
-      childKey => apiRes.content[childKey].id,
+    listsById[apiRes.content[commentKey].post_id] = apiRes.content[commentKey].replies.map(
+      childKey => apiRes.content[childKey].post_id,
     );
   });
 

--- a/src/client/comments/commentsReducer.js
+++ b/src/client/comments/commentsReducer.js
@@ -31,7 +31,7 @@ const mapCommentsBasedOnId = (data, action) => {
     ) {
       comment.focus = true;
     }
-    commentsList[data[key].id] = comment;
+    commentsList[data[key].post_id] = comment;
   });
   return commentsList;
 };

--- a/src/client/feed/feedReducer.js
+++ b/src/client/feed/feedReducer.js
@@ -27,11 +27,11 @@ const feedIdsList = (state = [], action) => {
     case feedTypes.GET_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_REPLIES.SUCCESS:
     case feedTypes.GET_BOOKMARKS.SUCCESS:
-      return action.payload.map(post => post.id);
+      return action.payload.map(post => post.post_id);
     case feedTypes.GET_MORE_FEED_CONTENT.SUCCESS:
     case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_MORE_REPLIES.SUCCESS:
-      return _.uniq([...state, ...action.payload.map(post => post.id)]);
+      return _.uniq([...state, ...action.payload.map(post => post.post_id)]);
     default:
       return state;
   }

--- a/src/client/post/postsReducer.js
+++ b/src/client/post/postsReducer.js
@@ -31,7 +31,7 @@ const posts = (state = initialState, action) => {
     case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS: {
       const commentsMoreList = {};
       action.payload.forEach(comment => {
-        commentsMoreList[comment.id] = comment;
+        commentsMoreList[comment.post_id] = { id: comment.post_id, ...comment };
       });
       return {
         ...state,
@@ -54,7 +54,7 @@ const posts = (state = initialState, action) => {
       };
 
       _.each(action.payload, post => {
-        list[post.id] = post;
+        list[post.post_id] = { id: post.post_id, ...post };
         postsStates[`${post.author}/${post.permlink}}`] = {
           fetching: false,
           loaded: true,


### PR DESCRIPTION
Still some features might be broken, as "IDs" are not useful at all as identifiers, because many possible IDs are assigned to the same post. We'd need to refactor bunch of code to not use IDs as identifiers.