### PR TITLE
Migrate to new Steemit API

### DIFF
--- a/src/client/app/Sidebar/RightSidebar.js
+++ b/src/client/app/Sidebar/RightSidebar.js
@@ -76,7 +76,6 @@ export default class RightSidebar extends React.Component {
           <Route path="/@:name/transfers" render={() => <WalletSidebar />} />
           <Route path="/trending/:tag" component={FeedSidebar} />
           <Route path="/created/:tag" component={FeedSidebar} />
-          <Route path="/active/:tag" component={FeedSidebar} />
           <Route path="/hot/:tag" component={FeedSidebar} />
           <Route path="/promoted/:tag" component={FeedSidebar} />
           <Route

--- a/src/client/comments/commentsActions.js
+++ b/src/client/comments/commentsActions.js
@@ -3,6 +3,7 @@ import { createCommentPermlink, getBodyPatchIfSmaller } from '../vendor/steemitH
 import { notify } from '../app/Notification/notificationActions';
 import { jsonParse } from '../helpers/formatter';
 import { createPostMetadata } from '../helpers/postHelpers';
+import { getPostKey } from '../helpers/stateHelpers';
 
 export const GET_COMMENTS = 'GET_COMMENTS';
 export const GET_COMMENTS_START = 'GET_COMMENTS_START';
@@ -21,19 +22,19 @@ export const LIKE_COMMENT_ERROR = '@comments/LIKE_COMMENT_ERROR';
 
 export const RELOAD_EXISTING_COMMENT = '@comments/RELOAD_EXISTING_COMMENT';
 export const reloadExistingComment = createAction(RELOAD_EXISTING_COMMENT, undefined, data => ({
-  commentId: data.id,
+  commentId: getPostKey(data),
 }));
 
 const getRootCommentsList = apiRes =>
   Object.keys(apiRes.content)
     .filter(commentKey => apiRes.content[commentKey].depth === 1)
-    .map(commentKey => apiRes.content[commentKey].post_id);
+    .map(commentKey => getPostKey(apiRes.content[commentKey]));
 
 const getCommentsChildrenLists = apiRes => {
   const listsById = {};
   Object.keys(apiRes.content).forEach(commentKey => {
-    listsById[apiRes.content[commentKey].post_id] = apiRes.content[commentKey].replies.map(
-      childKey => apiRes.content[childKey].post_id,
+    listsById[getPostKey(apiRes.content[commentKey])] = apiRes.content[commentKey].replies.map(
+      childKey => getPostKey(apiRes.content[childKey]),
     );
   });
 

--- a/src/client/comments/commentsReducer.js
+++ b/src/client/comments/commentsReducer.js
@@ -1,4 +1,5 @@
 import * as commentsTypes from './commentsActions';
+import { getPostKey } from '../helpers/stateHelpers';
 
 const initialState = {
   childrenById: {},
@@ -31,7 +32,10 @@ const mapCommentsBasedOnId = (data, action) => {
     ) {
       comment.focus = true;
     }
-    commentsList[data[key].post_id] = comment;
+
+    const newKey = getPostKey(data[key]);
+
+    commentsList[newKey] = { ...comment, id: newKey };
   });
   return commentsList;
 };
@@ -43,11 +47,14 @@ const commentsData = (state = {}, action) => {
         ...state,
         ...mapCommentsBasedOnId(action.payload.content, action),
       };
-    case commentsTypes.RELOAD_EXISTING_COMMENT:
+    case commentsTypes.RELOAD_EXISTING_COMMENT: {
+      const key = getPostKey(action.payload);
+
       return {
         ...state,
-        [action.payload.id]: action.payload,
+        [key]: { ...action.payload, id: key },
       };
+    }
     default:
       return state;
   }

--- a/src/client/components/TopicSelector.js
+++ b/src/client/components/TopicSelector.js
@@ -20,9 +20,6 @@ const TopicSelector = ({ sort, isSingle, topics, onTopicClose, onSortChange }) =
       <SortSelector.Item key="created">
         <FormattedMessage id="sort_created" defaultMessage="Created" />
       </SortSelector.Item>
-      <SortSelector.Item key="active">
-        <FormattedMessage id="sort_active" defaultMessage="Active" />
-      </SortSelector.Item>
       <SortSelector.Item key="hot">
         <FormattedMessage id="sort_hot" defaultMessage="Hot" />
       </SortSelector.Item>

--- a/src/client/components/__tests__/TopicSelector.js
+++ b/src/client/components/__tests__/TopicSelector.js
@@ -5,7 +5,7 @@ import TopicSelector from '../TopicSelector';
 describe('<TopicSelector />', () => {
   it('renders without exploding', () => {
     const props = {
-      sort: 'active',
+      sort: 'trending',
       isSingle: true,
       bold: true,
       topics: ['busy', 'introduceyourself', 'steemfest'],

--- a/src/client/components/__tests__/__snapshots__/TopicSelector.js.snap
+++ b/src/client/components/__tests__/__snapshots__/TopicSelector.js.snap
@@ -9,7 +9,7 @@ ShallowWrapper {
     isSingle={true}
     onSortChange={[Function]}
     onTopicClose={[Function]}
-    sort="active"
+    sort="trending"
     topics={
       Array [
         "busy",
@@ -55,7 +55,7 @@ ShallowWrapper {
         </div>,
         <SortSelector
           onChange={[Function]}
-          sort="active"
+          sort="trending"
         >
           <PopoverMenuItem
             bold={true}
@@ -80,19 +80,6 @@ ShallowWrapper {
             <FormattedMessage
               defaultMessage="Created"
               id="sort_created"
-              values={Object {}}
-            />
-          </PopoverMenuItem>
-          <PopoverMenuItem
-            bold={true}
-            disabled={false}
-            fullScreenHidden={false}
-            itemKey=""
-            onClick={[Function]}
-          >
-            <FormattedMessage
-              defaultMessage="Active"
-              id="sort_active"
               values={Object {}}
             />
           </PopoverMenuItem>
@@ -229,19 +216,6 @@ ShallowWrapper {
               onClick={[Function]}
             >
               <FormattedMessage
-                defaultMessage="Active"
-                id="sort_active"
-                values={Object {}}
-              />
-            </PopoverMenuItem>,
-            <PopoverMenuItem
-              bold={true}
-              disabled={false}
-              fullScreenHidden={false}
-              itemKey=""
-              onClick={[Function]}
-            >
-              <FormattedMessage
                 defaultMessage="Hot"
                 id="sort_hot"
                 values={Object {}}
@@ -249,7 +223,7 @@ ShallowWrapper {
             </PopoverMenuItem>,
           ],
           "onChange": [Function],
-          "sort": "active",
+          "sort": "trending",
         },
         "ref": null,
         "rendered": Array [
@@ -309,38 +283,6 @@ ShallowWrapper {
               "props": Object {
                 "defaultMessage": "Created",
                 "id": "sort_created",
-                "values": Object {},
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": "active",
-            "nodeType": "function",
-            "props": Object {
-              "bold": true,
-              "children": <FormattedMessage
-                defaultMessage="Active"
-                id="sort_active"
-                values={Object {}}
-              />,
-              "disabled": false,
-              "fullScreenHidden": false,
-              "itemKey": "",
-              "onClick": [Function],
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "defaultMessage": "Active",
-                "id": "sort_active",
                 "values": Object {},
               },
               "ref": null,
@@ -418,7 +360,7 @@ ShallowWrapper {
           </div>,
           <SortSelector
             onChange={[Function]}
-            sort="active"
+            sort="trending"
           >
             <PopoverMenuItem
               bold={true}
@@ -443,19 +385,6 @@ ShallowWrapper {
               <FormattedMessage
                 defaultMessage="Created"
                 id="sort_created"
-                values={Object {}}
-              />
-            </PopoverMenuItem>
-            <PopoverMenuItem
-              bold={true}
-              disabled={false}
-              fullScreenHidden={false}
-              itemKey=""
-              onClick={[Function]}
-            >
-              <FormattedMessage
-                defaultMessage="Active"
-                id="sort_active"
                 values={Object {}}
               />
             </PopoverMenuItem>
@@ -592,19 +521,6 @@ ShallowWrapper {
                 onClick={[Function]}
               >
                 <FormattedMessage
-                  defaultMessage="Active"
-                  id="sort_active"
-                  values={Object {}}
-                />
-              </PopoverMenuItem>,
-              <PopoverMenuItem
-                bold={true}
-                disabled={false}
-                fullScreenHidden={false}
-                itemKey=""
-                onClick={[Function]}
-              >
-                <FormattedMessage
                   defaultMessage="Hot"
                   id="sort_hot"
                   values={Object {}}
@@ -612,7 +528,7 @@ ShallowWrapper {
               </PopoverMenuItem>,
             ],
             "onChange": [Function],
-            "sort": "active",
+            "sort": "trending",
           },
           "ref": null,
           "rendered": Array [
@@ -672,38 +588,6 @@ ShallowWrapper {
                 "props": Object {
                   "defaultMessage": "Created",
                   "id": "sort_created",
-                  "values": Object {},
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": "active",
-              "nodeType": "function",
-              "props": Object {
-                "bold": true,
-                "children": <FormattedMessage
-                  defaultMessage="Active"
-                  id="sort_active"
-                  values={Object {}}
-                />,
-                "disabled": false,
-                "fullScreenHidden": false,
-                "itemKey": "",
-                "onClick": [Function],
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "defaultMessage": "Active",
-                  "id": "sort_active",
                   "values": Object {},
                 },
                 "ref": null,

--- a/src/client/feed/feedReducer.js
+++ b/src/client/feed/feedReducer.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import * as feedTypes from './feedActions';
 import { TOGGLE_BOOKMARK } from '../bookmarks/bookmarksActions';
+import { getPostKey } from '../helpers/stateHelpers';
 
 const initialState = {
   feed: {},
@@ -27,11 +28,11 @@ const feedIdsList = (state = [], action) => {
     case feedTypes.GET_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_REPLIES.SUCCESS:
     case feedTypes.GET_BOOKMARKS.SUCCESS:
-      return action.payload.map(post => post.post_id);
+      return action.payload.map(getPostKey);
     case feedTypes.GET_MORE_FEED_CONTENT.SUCCESS:
     case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS:
     case feedTypes.GET_MORE_REPLIES.SUCCESS:
-      return _.uniq([...state, ...action.payload.map(post => post.post_id)]);
+      return _.uniq([...state, ...action.payload.map(getPostKey)]);
     default:
       return state;
   }

--- a/src/client/helpers/stateHelpers.js
+++ b/src/client/helpers/stateHelpers.js
@@ -143,3 +143,4 @@ export const createAsyncActionType = type => ({
 });
 
 export const getUserDetailsKey = username => `user-${username}`;
+export const getPostKey = post => `${post.author}/${post.permlink}`;

--- a/src/client/helpers/stateHelpers.js
+++ b/src/client/helpers/stateHelpers.js
@@ -3,7 +3,6 @@ export const getFeedFromState = (sortBy, category = 'all', state) => {
     case 'feed':
     case 'hot':
     case 'created':
-    case 'active':
     case 'trending':
     case 'comments':
     case 'blog':
@@ -21,7 +20,6 @@ export const getFeedLoadingFromState = (sortBy, category = 'all', feedState) => 
     case 'feed':
     case 'hot':
     case 'created':
-    case 'active':
     case 'trending':
     case 'comments':
     case 'blog':
@@ -39,7 +37,6 @@ export const getFeedFetchedFromState = (sortBy, category = 'all', feedState) => 
     case 'feed':
     case 'hot':
     case 'created':
-    case 'active':
     case 'trending':
     case 'comments':
     case 'blog':
@@ -58,7 +55,6 @@ export const getFeedHasMoreFromState = (sortBy, listName = 'all', feedState) => 
     case 'hot':
     case 'cashout':
     case 'created':
-    case 'active':
     case 'trending':
     case 'comments':
     case 'blog':
@@ -77,7 +73,6 @@ export const getFeedFailedFromState = (sortBy, listName = 'all', feedState) => {
     case 'hot':
     case 'cashout':
     case 'created':
-    case 'active':
     case 'trending':
     case 'comments':
     case 'blog':

--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -167,7 +167,6 @@
   "sort_by": "Sort by",
   "sort_trending": "Trending",
   "sort_created": "New",
-  "sort_active": "Active",
   "sort_hot": "Hot",
   "sort_promoted": "Promoted",
   "sort_best": "Best",

--- a/src/client/post/postsReducer.js
+++ b/src/client/post/postsReducer.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import * as feedTypes from '../feed/feedActions';
 import * as postsActions from './postActions';
 import * as commentsActions from '../comments/commentsActions';
+import { getPostKey } from '../helpers/stateHelpers';
 
 const postItem = (state = {}, action) => {
   switch (action.type) {
@@ -31,7 +32,8 @@ const posts = (state = initialState, action) => {
     case feedTypes.GET_MORE_USER_COMMENTS.SUCCESS: {
       const commentsMoreList = {};
       action.payload.forEach(comment => {
-        commentsMoreList[comment.post_id] = { id: comment.post_id, ...comment };
+        const key = getPostKey(comment);
+        commentsMoreList[key] = { ...comment, id: key };
       });
       return {
         ...state,
@@ -54,8 +56,9 @@ const posts = (state = initialState, action) => {
       };
 
       _.each(action.payload, post => {
-        list[post.post_id] = { id: post.post_id, ...post };
-        postsStates[`${post.author}/${post.permlink}}`] = {
+        const key = getPostKey(post);
+        list[key] = { ...post, id: key };
+        postsStates[key] = {
           fetching: false,
           loaded: true,
           failed: false,
@@ -74,7 +77,7 @@ const posts = (state = initialState, action) => {
         ...state,
         postsStates: {
           ...state.postsStates,
-          [`${action.meta.author}/${action.meta.permlink}}`]: {
+          [getPostKey(action.meta)]: {
             fetching: true,
             loaded: false,
             failed: false,
@@ -82,18 +85,21 @@ const posts = (state = initialState, action) => {
         },
       };
     case postsActions.GET_CONTENT.SUCCESS: {
+      const key = getPostKey(action.payload);
+
       const baseState = {
         ...state,
         list: {
           ...state.list,
-          [action.payload.id]: {
-            ...state.list[action.payload.id],
+          [key]: {
+            ...state.list[key],
             ...action.payload,
+            id: key,
           },
         },
         postsStates: {
           ...state.postsStates,
-          [`${action.meta.author}/${action.meta.permlink}}`]: {
+          [getPostKey(action.meta)]: {
             fetching: false,
             loaded: true,
             failed: false,
@@ -103,7 +109,7 @@ const posts = (state = initialState, action) => {
       if (action.meta.afterLike) {
         return {
           ...baseState,
-          pendingLikes: _.omit(state.pendingLikes, action.payload.id),
+          pendingLikes: _.omit(state.pendingLikes, getPostKey(action.payload)),
         };
       }
       return baseState;
@@ -113,7 +119,7 @@ const posts = (state = initialState, action) => {
         ...state,
         postsStates: {
           ...state.postsStates,
-          [`${action.meta.author}/${action.meta.permlink}}`]: {
+          [getPostKey(action.meta)]: {
             fetching: false,
             loaded: false,
             failed: true,

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -139,7 +139,7 @@ const routes = [
         component: ExitPage,
       },
       {
-        path: '/:sortBy(trending|created|active|hot|promoted)?/:category?',
+        path: '/:sortBy(trending|created|hot|promoted)?/:category?',
         component: Page,
       },
       {


### PR DESCRIPTION
- Remove deprecated `active` sorting.
- Use `author/permlink` instead of `post_id` as it is might not be unique right now.