### PR TITLE
edit posts older than 7 days

### DIFF
--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -227,7 +227,7 @@ class Comment extends React.Component {
     const anchorId = `@${comment.author}/${comment.permlink}`;
     const anchorLink = `${comment.url.slice(0, comment.url.indexOf('#'))}#${anchorId}`;
 
-    const editable = comment.author === user.name && comment.cashout_time !== '1969-12-31T23:59:59';
+    const editable = comment.author === user.name;
     const commentAuthorReputation = formatter.reputation(comment.author_reputation);
     const showCommentContent = commentAuthorReputation >= 0 || showHiddenComment;
 

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -278,7 +278,7 @@ class StoryFull extends React.Component {
 
     let popoverMenu = [];
 
-    if (ownPost && post.cashout_time !== '1969-12-31T23:59:59') {
+    if (ownPost) {
       popoverMenu = [
         ...popoverMenu,
         <PopoverMenuItem key="edit">

--- a/src/client/components/StoryFooter/Buttons.js
+++ b/src/client/components/StoryFooter/Buttons.js
@@ -169,7 +169,7 @@ export default class Buttons extends React.Component {
 
     let popoverMenu = [];
 
-    if (ownPost && post.cashout_time !== '1969-12-31T23:59:59') {
+    if (ownPost) {
       popoverMenu = [
         ...popoverMenu,
         <PopoverMenuItem key="edit">


### PR DESCRIPTION
Fixes #2137

### Changes

* Enable edit function for posts older than 7 days.

### Test plan

* [x] Step 1
Pick any post older than 7 days

* [x] Step 2
Edit as much as you want :)

* [x] Step 3
Check if it is edited, as below. Simple, right?

### Demo (optional)
#### Before
![](https://ipfs.busy.org/ipfs/QmScUVf5MN2T4u8pFkRq3BQYUNnnMEKcYwxakiePgke37j)

#### After

It worked like a charm :)

Here is my old post that I actually edit by busy on my local dev server. Of course, the actual edit has been reflected on the real Steem blockchain. https://steemit.com/@blockchainstudio/steem-python-library-sbdtorshares-bugfix

This is my Christmas gift to Steem community :) Hope that it'll be merged soon. Merry Christmas! 

![](https://ipfs.busy.org/ipfs/QmQyuuwg9XKFyrFr3NfzkVsWnrRJpWV534xLix7vzTe8eq)

![](https://ipfs.busy.org/ipfs/Qmd6Ce4xo1WnsYXtLQDDBQoX6gwQZANgusF5RhtRGrug3Y)

