### PR TITLE
[Suggestion] show powerdown information in wallet

### DIFF
--- a/src/client/vendor/steemitHelpers.js
+++ b/src/client/vendor/steemitHelpers.js
@@ -192,6 +192,12 @@ export const calculateTotalDelegatedSP = (user, totalVestingShares, totalVesting
   return receivedSP - delegatedSP;
 };
 
+export const calculatePendingWithdrawalSP = (user, totalVestingShares, totalVestingFundSteem) => {
+  return parseFloat(
+    formatter.vestToSteem(user.vesting_withdraw_rate, totalVestingShares, totalVestingFundSteem),
+  );
+};
+
 export const calculateVotingPower = user => {
   const secondsago = (new Date().getTime() - new Date(user.last_vote_time + 'Z').getTime()) / 1000;
   return Math.min(10000, user.voting_power + 10000 * secondsago / 432000) / 10000;

--- a/src/client/wallet/UserWalletSummary.js
+++ b/src/client/wallet/UserWalletSummary.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedNumber } from 'react-intl';
+import { FormattedMessage, FormattedNumber, FormattedDate, FormattedTime } from 'react-intl';
 import formatter from '../helpers/steemitFormatter';
-import { calculateTotalDelegatedSP, calculateEstAccountValue } from '../vendor/steemitHelpers';
+import {
+  calculateTotalDelegatedSP,
+  calculateEstAccountValue,
+  calculatePendingWithdrawalSP,
+} from '../vendor/steemitHelpers';
 import BTooltip from '../components/BTooltip';
 import Loading from '../components/Icon/Loading';
 import USDDisplay from '../components/Utils/USDDisplay';
@@ -28,11 +32,43 @@ const getFormattedTotalDelegatedSP = (user, totalVestingShares, totalVestingFund
         }
       >
         <span>
-          {totalDelegatedSP > 0 ? '(+' : '('}
+          {totalDelegatedSP > 0 ? ' (+' : ' ('}
           <FormattedNumber
             value={calculateTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
           />
-          {' SP)'}
+          {')'}
+        </span>
+      </BTooltip>
+    );
+  }
+
+  return null;
+};
+
+const getFormattedPendingWithdrawalSP = (user, totalVestingShares, totalVestingFundSteem) => {
+  const pendingWithdrawalSP = calculatePendingWithdrawalSP(
+    user,
+    totalVestingShares,
+    totalVestingFundSteem,
+  );
+
+  if (pendingWithdrawalSP !== 0) {
+    return (
+      <BTooltip
+        title={
+          <span>
+            <FormattedMessage
+              id="steem_power_pending_withdrawal_tooltip"
+              defaultMessage="The next power down is scheduled to happen on "
+            />
+            <FormattedDate value={`${user.next_vesting_withdrawal}Z`} />{' '}
+            <FormattedTime value={`${user.next_vesting_withdrawal}Z`} />
+          </span>
+        }
+      >
+        <span>
+          {' - '}
+          <FormattedNumber value={pendingWithdrawalSP} />
         </span>
       </BTooltip>
     );
@@ -87,8 +123,9 @@ const UserWalletSummary = ({
                 ),
               )}
             />
-            {' SP '}
+            {getFormattedPendingWithdrawalSP(user, totalVestingShares, totalVestingFundSteem)}
             {getFormattedTotalDelegatedSP(user, totalVestingShares, totalVestingFundSteem)}
+            {' SP'}
           </span>
         )}
       </div>

--- a/src/client/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
+++ b/src/client/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
@@ -82,7 +82,31 @@ ShallowWrapper {
               <FormattedNumber
                 value={0}
               />
-               SP 
+              <BTooltip
+                title={
+                  <span>
+                    <FormattedMessage
+                      defaultMessage="The next power down is scheduled to happen on "
+                      id="steem_power_pending_withdrawal_tooltip"
+                      values={Object {}}
+                    />
+                    <FormattedDate
+                      value="undefinedZ"
+                    />
+                     
+                    <FormattedTime
+                      value="undefinedZ"
+                    />
+                  </span>
+                }
+              >
+                <span>
+                   - 
+                  <FormattedNumber
+                    value={NaN}
+                  />
+                </span>
+              </BTooltip>
               <BTooltip
                 title={
                   <span>
@@ -95,13 +119,14 @@ ShallowWrapper {
                 }
               >
                 <span>
-                  (
+                   (
                   <FormattedNumber
                     value={NaN}
                   />
-                   SP)
+                  )
                 </span>
               </BTooltip>
+               SP
             </span>
           </div>
         </div>,
@@ -334,7 +359,31 @@ ShallowWrapper {
                 <FormattedNumber
                   value={0}
                 />
-                 SP 
+                <BTooltip
+                  title={
+                    <span>
+                      <FormattedMessage
+                        defaultMessage="The next power down is scheduled to happen on "
+                        id="steem_power_pending_withdrawal_tooltip"
+                        values={Object {}}
+                      />
+                      <FormattedDate
+                        value="undefinedZ"
+                      />
+                       
+                      <FormattedTime
+                        value="undefinedZ"
+                      />
+                    </span>
+                  }
+                >
+                  <span>
+                     - 
+                    <FormattedNumber
+                      value={NaN}
+                    />
+                  </span>
+                </BTooltip>
                 <BTooltip
                   title={
                     <span>
@@ -347,13 +396,14 @@ ShallowWrapper {
                   }
                 >
                   <span>
-                    (
+                     (
                     <FormattedNumber
                       value={NaN}
                     />
-                     SP)
+                    )
                   </span>
                 </BTooltip>
+                 SP
               </span>
             </div>,
           ],
@@ -409,7 +459,31 @@ ShallowWrapper {
                 <FormattedNumber
                   value={0}
                 />
-                 SP 
+                <BTooltip
+                  title={
+                    <span>
+                      <FormattedMessage
+                        defaultMessage="The next power down is scheduled to happen on "
+                        id="steem_power_pending_withdrawal_tooltip"
+                        values={Object {}}
+                      />
+                      <FormattedDate
+                        value="undefinedZ"
+                      />
+                       
+                      <FormattedTime
+                        value="undefinedZ"
+                      />
+                    </span>
+                  }
+                >
+                  <span>
+                     - 
+                    <FormattedNumber
+                      value={NaN}
+                    />
+                  </span>
+                </BTooltip>
                 <BTooltip
                   title={
                     <span>
@@ -422,13 +496,14 @@ ShallowWrapper {
                   }
                 >
                   <span>
-                    (
+                     (
                     <FormattedNumber
                       value={NaN}
                     />
-                     SP)
+                    )
                   </span>
                 </BTooltip>
+                 SP
               </span>,
               "className": "UserWalletSummary__value",
             },
@@ -442,7 +517,31 @@ ShallowWrapper {
                   <FormattedNumber
                     value={0}
                   />,
-                  " SP ",
+                  <BTooltip
+                    title={
+                      <span>
+                        <FormattedMessage
+                          defaultMessage="The next power down is scheduled to happen on "
+                          id="steem_power_pending_withdrawal_tooltip"
+                          values={Object {}}
+                        />
+                        <FormattedDate
+                          value="undefinedZ"
+                        />
+                         
+                        <FormattedTime
+                          value="undefinedZ"
+                        />
+                      </span>
+                    }
+                  >
+                    <span>
+                       - 
+                      <FormattedNumber
+                        value={NaN}
+                      />
+                    </span>
+                  </BTooltip>,
                   <BTooltip
                     title={
                       <span>
@@ -455,13 +554,14 @@ ShallowWrapper {
                     }
                   >
                     <span>
-                      (
+                       (
                       <FormattedNumber
                         value={NaN}
                       />
-                       SP)
+                      )
                     </span>
                   </BTooltip>,
+                  " SP",
                 ],
               },
               "ref": null,
@@ -477,18 +577,75 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                " SP ",
                 Object {
                   "instance": null,
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
                     "children": <span>
-                      (
+                       - 
                       <FormattedNumber
                         value={NaN}
                       />
-                       SP)
+                    </span>,
+                    "title": <span>
+                      <FormattedMessage
+                        defaultMessage="The next power down is scheduled to happen on "
+                        id="steem_power_pending_withdrawal_tooltip"
+                        values={Object {}}
+                      />
+                      <FormattedDate
+                        value="undefinedZ"
+                      />
+                       
+                      <FormattedTime
+                        value="undefinedZ"
+                      />
+                    </span>,
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        " - ",
+                        <FormattedNumber
+                          value={NaN}
+                        />,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      " - ",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "value": NaN,
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                    ],
+                    "type": "span",
+                  },
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": <span>
+                       (
+                      <FormattedNumber
+                        value={NaN}
+                      />
+                      )
                     </span>,
                     "title": <span>
                       <FormattedMessage
@@ -505,16 +662,16 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        "(",
+                        " (",
                         <FormattedNumber
                           value={NaN}
                         />,
-                        " SP)",
+                        ")",
                       ],
                     },
                     "ref": null,
                     "rendered": Array [
-                      "(",
+                      " (",
                       Object {
                         "instance": null,
                         "key": undefined,
@@ -526,12 +683,13 @@ ShallowWrapper {
                         "rendered": null,
                         "type": [Function],
                       },
-                      " SP)",
+                      ")",
                     ],
                     "type": "span",
                   },
                   "type": [Function],
                 },
+                " SP",
               ],
               "type": "span",
             },
@@ -958,7 +1116,31 @@ ShallowWrapper {
                 <FormattedNumber
                   value={0}
                 />
-                 SP 
+                <BTooltip
+                  title={
+                    <span>
+                      <FormattedMessage
+                        defaultMessage="The next power down is scheduled to happen on "
+                        id="steem_power_pending_withdrawal_tooltip"
+                        values={Object {}}
+                      />
+                      <FormattedDate
+                        value="undefinedZ"
+                      />
+                       
+                      <FormattedTime
+                        value="undefinedZ"
+                      />
+                    </span>
+                  }
+                >
+                  <span>
+                     - 
+                    <FormattedNumber
+                      value={NaN}
+                    />
+                  </span>
+                </BTooltip>
                 <BTooltip
                   title={
                     <span>
@@ -971,13 +1153,14 @@ ShallowWrapper {
                   }
                 >
                   <span>
-                    (
+                     (
                     <FormattedNumber
                       value={NaN}
                     />
-                     SP)
+                    )
                   </span>
                 </BTooltip>
+                 SP
               </span>
             </div>
           </div>,
@@ -1210,7 +1393,31 @@ ShallowWrapper {
                   <FormattedNumber
                     value={0}
                   />
-                   SP 
+                  <BTooltip
+                    title={
+                      <span>
+                        <FormattedMessage
+                          defaultMessage="The next power down is scheduled to happen on "
+                          id="steem_power_pending_withdrawal_tooltip"
+                          values={Object {}}
+                        />
+                        <FormattedDate
+                          value="undefinedZ"
+                        />
+                         
+                        <FormattedTime
+                          value="undefinedZ"
+                        />
+                      </span>
+                    }
+                  >
+                    <span>
+                       - 
+                      <FormattedNumber
+                        value={NaN}
+                      />
+                    </span>
+                  </BTooltip>
                   <BTooltip
                     title={
                       <span>
@@ -1223,13 +1430,14 @@ ShallowWrapper {
                     }
                   >
                     <span>
-                      (
+                       (
                       <FormattedNumber
                         value={NaN}
                       />
-                       SP)
+                      )
                     </span>
                   </BTooltip>
+                   SP
                 </span>
               </div>,
             ],
@@ -1285,7 +1493,31 @@ ShallowWrapper {
                   <FormattedNumber
                     value={0}
                   />
-                   SP 
+                  <BTooltip
+                    title={
+                      <span>
+                        <FormattedMessage
+                          defaultMessage="The next power down is scheduled to happen on "
+                          id="steem_power_pending_withdrawal_tooltip"
+                          values={Object {}}
+                        />
+                        <FormattedDate
+                          value="undefinedZ"
+                        />
+                         
+                        <FormattedTime
+                          value="undefinedZ"
+                        />
+                      </span>
+                    }
+                  >
+                    <span>
+                       - 
+                      <FormattedNumber
+                        value={NaN}
+                      />
+                    </span>
+                  </BTooltip>
                   <BTooltip
                     title={
                       <span>
@@ -1298,13 +1530,14 @@ ShallowWrapper {
                     }
                   >
                     <span>
-                      (
+                       (
                       <FormattedNumber
                         value={NaN}
                       />
-                       SP)
+                      )
                     </span>
                   </BTooltip>
+                   SP
                 </span>,
                 "className": "UserWalletSummary__value",
               },
@@ -1318,7 +1551,31 @@ ShallowWrapper {
                     <FormattedNumber
                       value={0}
                     />,
-                    " SP ",
+                    <BTooltip
+                      title={
+                        <span>
+                          <FormattedMessage
+                            defaultMessage="The next power down is scheduled to happen on "
+                            id="steem_power_pending_withdrawal_tooltip"
+                            values={Object {}}
+                          />
+                          <FormattedDate
+                            value="undefinedZ"
+                          />
+                           
+                          <FormattedTime
+                            value="undefinedZ"
+                          />
+                        </span>
+                      }
+                    >
+                      <span>
+                         - 
+                        <FormattedNumber
+                          value={NaN}
+                        />
+                      </span>
+                    </BTooltip>,
                     <BTooltip
                       title={
                         <span>
@@ -1331,13 +1588,14 @@ ShallowWrapper {
                       }
                     >
                       <span>
-                        (
+                         (
                         <FormattedNumber
                           value={NaN}
                         />
-                         SP)
+                        )
                       </span>
                     </BTooltip>,
+                    " SP",
                   ],
                 },
                 "ref": null,
@@ -1353,18 +1611,75 @@ ShallowWrapper {
                     "rendered": null,
                     "type": [Function],
                   },
-                  " SP ",
                   Object {
                     "instance": null,
                     "key": undefined,
                     "nodeType": "class",
                     "props": Object {
                       "children": <span>
-                        (
+                         - 
                         <FormattedNumber
                           value={NaN}
                         />
-                         SP)
+                      </span>,
+                      "title": <span>
+                        <FormattedMessage
+                          defaultMessage="The next power down is scheduled to happen on "
+                          id="steem_power_pending_withdrawal_tooltip"
+                          values={Object {}}
+                        />
+                        <FormattedDate
+                          value="undefinedZ"
+                        />
+                         
+                        <FormattedTime
+                          value="undefinedZ"
+                        />
+                      </span>,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          " - ",
+                          <FormattedNumber
+                            value={NaN}
+                          />,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        " - ",
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "value": NaN,
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": [Function],
+                        },
+                      ],
+                      "type": "span",
+                    },
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": <span>
+                         (
+                        <FormattedNumber
+                          value={NaN}
+                        />
+                        )
                       </span>,
                       "title": <span>
                         <FormattedMessage
@@ -1381,16 +1696,16 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": Array [
-                          "(",
+                          " (",
                           <FormattedNumber
                             value={NaN}
                           />,
-                          " SP)",
+                          ")",
                         ],
                       },
                       "ref": null,
                       "rendered": Array [
-                        "(",
+                        " (",
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -1402,12 +1717,13 @@ ShallowWrapper {
                           "rendered": null,
                           "type": [Function],
                         },
-                        " SP)",
+                        ")",
                       ],
                       "type": "span",
                     },
                     "type": [Function],
                   },
+                  " SP",
                 ],
                 "type": "span",
               },


### PR DESCRIPTION
### Changes


* Show the powerdown amount in the wallet
* Show the tooltip with next powerdown(withdrawal) date

### Test plan

Explain how to test changes you made.

* [ ] Pick a user powering down to check powerdown information is shown
* [ ] Pick another user not powering down to check powerdown information is not shown.

### Demo

![](https://ipfs.busy.org/ipfs/Qmf1qRMhNrpWzoFdV9ZYJiAe7DTwthJnVdvsJse5i5oZz2)
> Currently, **Busy shows nothing!**

![](https://ipfs.busy.org/ipfs/QmXA7cJEUNADju9qjmuFaousDm8kFRtpC6TpQ81K82rqKW)
> After, Busy shows both powerdown and delegation in a compact form.

### Benefits

Given that most users are not familiar with steemd.com or at least not using it daily basis, widely used UIs should show sufficient powerdown information. There are several benefits.

1. Hacking prevention
There are many cases where hackers start the powerdown and victims even don't recognize it! If the information is properly shown, this hacking can be prevented.

2. Correct vote value
It can also prevent a bug of incorrect vote value. Even if the vote value is shown correctly, e.g., steempeak, users may wonder why their vote value is quite low. Note that around the end of 13 weeks of powerdown, the difference can be huge. In Ned's case, it's almost twice, and much more than twice next week.

3. Stopping powerdown
In addition, users powering down may change their mind to stop the powerdown if the information is clearly shown everyday. Especially when it's almost done (again, for instance, Ned), the powerdown amount is quite big compared to the remaining so the chance of changing their mind might be pretty high :)