### PR TITLE
fix-reblogged-by

### DIFF
--- a/src/client/components/Story/Story.js
+++ b/src/client/components/Story/Story.js
@@ -275,7 +275,7 @@ class Story extends React.Component {
 
     let rebloggedUI = null;
 
-    if (post.first_reblogged_by) {
+    if (post.reblogged_by) {
       rebloggedUI = (
         <div className="Story__reblog">
           <i className="iconfont icon-share1" />
@@ -284,8 +284,8 @@ class Story extends React.Component {
             defaultMessage="{username} reblogged"
             values={{
               username: (
-                <Link to={`/@${post.first_reblogged_by}`}>
-                  <span className="username">{post.first_reblogged_by}</span>
+                <Link to={`/@${post.reblogged_by[0]}`}>
+                  <span className="username">{post.reblogged_by[0]}</span>
                 </Link>
               ),
             }}


### PR DESCRIPTION
Fixes #2149

### Changes

* Fix reblogged_by

`post.first_reblogged_by` returns null. `post.reblogged_by` should be used as follows:
https://github.com/steemit/condenser/blob/7430aca58ae9f86e501f52e3cf8dba5efc9fe3e0/src/app/components/cards/PostSummary.jsx#L70

### Test plan

Explain how to test changes you made.

* [x] Go to feed
* [x] Compare it with the feed on Steemit.com

### Demo
![](https://ipfs.busy.org/ipfs/QmawUqsG8u2QxJctzQcWK5tctoGc8f3gCtjYgdAq5U7ETi)
> Busy.org: my feed (rosatravels isn't my following)


![](https://ipfs.busy.org/ipfs/QmcA4amxmRqYFNSvMg5nZkipkzXWHmqydzxEoDRqsCzdnm)
> Steemit.com shows the reblogged information correctly

![](https://ipfs.busy.org/ipfs/QmanpE1GT84n5cWjFBMEA1E6gpynFZUAyAaDc2m5chVgai)
> **After the fix on my local dev server** 


In addition, to show 'reblogged' in blog (not feed), the current code should be changed. Currently there is no easy way to differentiate if it's feed or blog. But any resteemed post in a blog is easily noticeable by author's name, so not important as reblogged_by in feed.

