### PR TITLE
feat: only open external links as _blank

### DIFF
--- a/src/client/comments/Comments.js
+++ b/src/client/comments/Comments.js
@@ -14,7 +14,6 @@ import {
   getVotingPower,
   getRewardFund,
   getVotePercent,
-  getRewriteLinks,
 } from '../reducers';
 import CommentsList from '../components/Comments/Comments';
 import * as commentsActions from './commentsActions';
@@ -32,7 +31,6 @@ import './Comments.less';
     sliderMode: getVotingPower(state),
     rewardFund: getRewardFund(state),
     defaultVotePercent: getVotePercent(state),
-    rewriteLinks: getRewriteLinks(state),
   }),
   dispatch =>
     bindActionCreators(
@@ -52,7 +50,6 @@ export default class Comments extends React.Component {
     user: PropTypes.shape().isRequired,
     rewardFund: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
-    rewriteLinks: PropTypes.bool.isRequired,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     username: PropTypes.string,
     post: PropTypes.shape(),
@@ -151,7 +148,6 @@ export default class Comments extends React.Component {
       sliderMode,
       rewardFund,
       defaultVotePercent,
-      rewriteLinks,
     } = this.props;
     const postId = post.id;
     let rootLevelComments = [];
@@ -186,7 +182,6 @@ export default class Comments extends React.Component {
           rewardFund={rewardFund}
           sliderMode={sliderMode}
           defaultVotePercent={defaultVotePercent}
-          rewriteLinks={rewriteLinks}
           onLikeClick={this.handleLikeClick}
           onDislikeClick={this.handleDislikeClick}
           onSendComment={this.props.sendComment}

--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -33,7 +33,6 @@ class Comment extends React.Component {
     sort: PropTypes.oneOf(['BEST', 'NEWEST', 'OLDEST', 'AUTHOR_REPUTATION']),
     rewardFund: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
-    rewriteLinks: PropTypes.bool,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     rootPostAuthor: PropTypes.string,
     commentsChildren: PropTypes.shape(),
@@ -53,7 +52,6 @@ class Comment extends React.Component {
   static defaultProps = {
     sort: 'BEST',
     sliderMode: 'auto',
-    rewriteLinks: false,
     rootPostAuthor: undefined,
     commentsChildren: undefined,
     pendingVotes: [],
@@ -221,7 +219,6 @@ class Comment extends React.Component {
       sliderMode,
       rewardFund,
       defaultVotePercent,
-      rewriteLinks,
     } = this.props;
     const { showHiddenComment } = this.state;
     const anchorId = `@${comment.author}/${comment.permlink}`;
@@ -251,7 +248,7 @@ class Comment extends React.Component {
           <FormattedMessage id="comment_collapsed" defaultMessage="Comment collapsed" />
         </div>
       ) : (
-        <BodyContainer rewriteLinks={rewriteLinks} body={comment.body} />
+        <BodyContainer body={comment.body} />
       );
     }
 
@@ -362,7 +359,6 @@ class Comment extends React.Component {
                   rewardFund={rewardFund}
                   sliderMode={sliderMode}
                   defaultVotePercent={defaultVotePercent}
-                  rewriteLinks={rewriteLinks}
                   onLikeClick={this.props.onLikeClick}
                   onDislikeClick={this.props.onDislikeClick}
                   onSendComment={this.props.onSendComment}

--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -33,7 +33,6 @@ class Comments extends React.Component {
     ),
     rewardFund: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
-    rewriteLinks: PropTypes.bool,
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
     show: PropTypes.bool,
     notify: PropTypes.func,
@@ -49,7 +48,6 @@ class Comments extends React.Component {
     rootLevelComments: [],
     commentsChildren: undefined,
     pendingVotes: [],
-    rewriteLinks: false,
     sliderMode: 'auto',
     show: false,
     notify: () => {},
@@ -205,7 +203,6 @@ class Comments extends React.Component {
       sliderMode,
       rewardFund,
       defaultVotePercent,
-      rewriteLinks,
     } = this.props;
     const { sort } = this.state;
 
@@ -275,7 +272,6 @@ class Comments extends React.Component {
               rewardFund={rewardFund}
               sliderMode={sliderMode}
               defaultVotePercent={defaultVotePercent}
-              rewriteLinks={rewriteLinks}
               onLikeClick={onLikeClick}
               onDislikeClick={onDislikeClick}
               onSendComment={this.props.onSendComment}

--- a/src/client/components/Story/Body.js
+++ b/src/client/components/Story/Body.js
@@ -64,6 +64,7 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object', options 
   parsedBody = sanitizeHtml(
     parsedBody,
     sanitizeConfig({
+      appUrl: options.appUrl,
       secureLinks: options.secureLinks,
     }),
   );
@@ -98,27 +99,28 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object', options 
 
 const Body = props => {
   const options = {
+    appUrl: props.appUrl,
     rewriteLinks: props.rewriteLinks,
     secureLinks: props.exitPageSetting,
   };
+
   const htmlSections = getHtml(props.body, props.jsonMetadata, 'Object', options);
   return <div className={classNames('Body', { 'Body--full': props.full })}>{htmlSections}</div>;
 };
 
 Body.propTypes = {
+  appUrl: PropTypes.string.isRequired,
+  rewriteLinks: PropTypes.bool.isRequired,
+  exitPageSetting: PropTypes.bool.isRequired,
   body: PropTypes.string,
   jsonMetadata: PropTypes.string,
   full: PropTypes.bool,
-  rewriteLinks: PropTypes.bool,
-  exitPageSetting: PropTypes.bool,
 };
 
 Body.defaultProps = {
   body: '',
   jsonMetadata: '',
   full: false,
-  rewriteLinks: false,
-  exitPageSetting: true,
 };
 
 export default Body;

--- a/src/client/components/Story/StoryFull.js
+++ b/src/client/components/Story/StoryFull.js
@@ -45,7 +45,6 @@ class StoryFull extends React.Component {
     defaultVotePercent: PropTypes.number.isRequired,
     onActionInitiated: PropTypes.func.isRequired,
     signature: PropTypes.string,
-    rewriteLinks: PropTypes.bool,
     pendingLike: PropTypes.bool,
     pendingFlag: PropTypes.bool,
     pendingFollow: PropTypes.bool,
@@ -64,7 +63,6 @@ class StoryFull extends React.Component {
 
   static defaultProps = {
     signature: null,
-    rewriteLinks: false,
     pendingLike: false,
     pendingFlag: false,
     pendingFollow: false,
@@ -188,7 +186,6 @@ class StoryFull extends React.Component {
       post,
       postState,
       signature,
-      rewriteLinks,
       pendingLike,
       pendingFlag,
       pendingFollow,
@@ -339,12 +336,7 @@ class StoryFull extends React.Component {
           onClick={this.handleContentClick}
         >
           {this.renderDtubeEmbedPlayer()}
-          <BodyContainer
-            full
-            rewriteLinks={rewriteLinks}
-            body={signedBody}
-            json_metadata={post.json_metadata}
-          />
+          <BodyContainer full body={signedBody} json_metadata={post.json_metadata} />
         </div>
       );
     }

--- a/src/client/containers/Story/BodyContainer.js
+++ b/src/client/containers/Story/BodyContainer.js
@@ -1,7 +1,9 @@
 import { connect } from 'react-redux';
 import Body from '../../components/Story/Body';
-import { getExitPageSetting } from '../../reducers';
+import { getAppUrl, getRewriteLinks, getExitPageSetting } from '../../reducers';
 
 export default connect(state => ({
+  appUrl: getAppUrl(state),
+  rewriteLinks: getRewriteLinks(state),
   exitPageSetting: getExitPageSetting(state),
 }))(Body);

--- a/src/client/helpers/constants.js
+++ b/src/client/helpers/constants.js
@@ -1,5 +1,4 @@
 export const knownDomains = [
-  'localhost',
   'busy.org',
   'staging.busy.org',
   'steemit.com',

--- a/src/client/helpers/regexHelpers.js
+++ b/src/client/helpers/regexHelpers.js
@@ -8,6 +8,4 @@ export const categoryRegex = /\/([^/]+)/;
 
 export const rewriteRegex = /"https?:\/\/(?:www)?steemit\.com(\/((([\w-]+\/)?@[\w.-]+\/[\w-]+)|(@[\w.-]+(\/(comments|followers|followed|reblogs|transfers|activity))?)|((trending|created|active|hot|promoted)(\/[\w-]+)?))?)?"/g;
 
-export const ownUrl = /^(localhost|busy\.org|staging\.busy\.org|busy-master-pr-\d+\.herokuapp.com)$/;
-
 export default null;

--- a/src/client/post/PostContent.js
+++ b/src/client/post/PostContent.js
@@ -21,7 +21,6 @@ import {
   getVotingPower,
   getRewardFund,
   getVotePercent,
-  getRewriteLinks,
   getAppUrl,
 } from '../reducers';
 import { editPost } from './Write/editorActions';
@@ -51,7 +50,6 @@ import DMCARemovedMessage from '../components/Story/DMCARemovedMessage';
     rewardFund: getRewardFund(state),
     defaultVotePercent: getVotePercent(state),
     appUrl: getAppUrl(state),
-    rewriteLinks: getRewriteLinks(state),
   }),
   {
     editPost,
@@ -78,7 +76,6 @@ class PostContent extends React.Component {
     saving: PropTypes.bool.isRequired,
     rewardFund: PropTypes.shape().isRequired,
     defaultVotePercent: PropTypes.number.isRequired,
-    rewriteLinks: PropTypes.bool.isRequired,
     appUrl: PropTypes.string.isRequired,
     bookmarks: PropTypes.shape(),
     sliderMode: PropTypes.oneOf(['on', 'off', 'auto']),
@@ -175,7 +172,6 @@ class PostContent extends React.Component {
       sliderMode,
       rewardFund,
       defaultVotePercent,
-      rewriteLinks,
       appUrl,
     } = this.props;
 
@@ -257,7 +253,6 @@ class PostContent extends React.Component {
           ownPost={author === user.name}
           sliderMode={sliderMode}
           defaultVotePercent={defaultVotePercent}
-          rewriteLinks={rewriteLinks}
           onLikeClick={this.handleLikeClick}
           onReportClick={this.handleReportClick}
           onShareClick={this.handleShareClick}

--- a/src/server/renderers/ssrRenderer.js
+++ b/src/server/renderers/ssrRenderer.js
@@ -12,7 +12,7 @@ export default function renderSsrPage(store, html, assets, template, noindex) {
 
   let scripts = `<script>window.__PRELOADED_STATE__ = ${JSON.stringify(preloadedState)
     .replace(/\u2028/g, '\\n')
-    .replace(/</g, '\\u003c')}</script>`;
+    .replace(/</g, '\\u003c')};</script>`;
 
   _.forEach(assets, asset => {
     if (asset.css) header += `<link rel="stylesheet" href="${asset.css}" />`;


### PR DESCRIPTION
### Changes

Summary of changes you made.

* Modify `BodyContainer` so it subscribes for `appUrl`, `rewriteLinks` and `exitPageSetting` (so we don't have to pass it from other parts o the app).
* Only treat relative and same-domain links as internal.
* Remove `localhost` from `knownDomains`.

### Test plan

Explain how to test changes you made.

* [x] Go to: http://localhost:3000/@hellosteem/busy-org-links-test
* [x] Relative and internal (localhost) links shouldn't be marked as external
* [x] Only Google and Heroku deployment links should use exit page.