### PR TITLE
fix: use username/permlink as a id for post recommendations

### DIFF
--- a/src/client/components/Sidebar/PostRecommendation.js
+++ b/src/client/components/Sidebar/PostRecommendation.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { usernameURLRegex } from '../../helpers/regexHelpers';
+import { getPostKey } from '../../helpers/stateHelpers';
 import formatter from '../../helpers/steemitFormatter';
 import Loading from '../../components/Icon/Loading';
 import steemAPI from '../../steemAPI';
@@ -102,10 +103,10 @@ class PostRecommendation extends Component {
 
     return filteredRecommendedPosts.map(post => (
       <PostRecommendationLink
+        key={getPostKey(post)}
         post={post}
         navigateToPost={this.navigateToPost}
         navigateToPostComments={this.navigateToPostComments}
-        key={post.id}
       />
     ));
   };


### PR DESCRIPTION
### Changes

Summary of changes you made.

* Use `author/permlink` as post id, due to API changes.

### Test plan

Explain how to test changes you made.

* [x] Go to http://localhost:3000/@hellosteem/kqj3n-test on development build.
* [x] Make sure there are no duplicate keys warning in the console.