### PR TITLE
fix: don't pass query string to matchRoutes

### DIFF
--- a/src/server/handlers/createSsrHandler.js
+++ b/src/server/handlers/createSsrHandler.js
@@ -39,7 +39,7 @@ export default function createSsrHandler(template) {
 
       const store = getStore(api);
 
-      const branch = matchRoutes(routes, req.url);
+      const branch = matchRoutes(routes, req.url.split('?')[0]);
       const promises = branch.map(({ route, match }) => {
         const fetchData = route.component.fetchData;
         if (fetchData instanceof Function) {


### PR DESCRIPTION
### Changes

* Don't pass query string to `matchRoutes`. `matchRoutes` won't match routes correctly if they contain a query string.

### Test plan

Explain how to test changes you made.

* [x] Enable dark theme on your account.
* [x] Go to: http://localhost:3000/exit?url=http%3A%2F%2Fgoogle.com
* [x] You should see yourself logged in instantely and dark theme should be applied from the beginning (provided SteemConnect isn't down at this moment).
