### PR TITLE
fix: reload comments using get_content

### DIFF
--- a/src/client/comments/Comments.js
+++ b/src/client/comments/Comments.js
@@ -60,7 +60,7 @@ export default class Comments extends React.Component {
     commentsList: PropTypes.shape(),
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
+        id: PropTypes.string,
         percent: PropTypes.number,
       }),
     ),

--- a/src/client/comments/commentsReducer.js
+++ b/src/client/comments/commentsReducer.js
@@ -1,5 +1,6 @@
+import { mapValues, omit, uniq } from 'lodash';
 import * as commentsTypes from './commentsActions';
-import { getPostKey } from '../helpers/stateHelpers';
+import { getPostKey, getParentKey } from '../helpers/stateHelpers';
 
 const initialState = {
   childrenById: {},
@@ -9,8 +10,19 @@ const initialState = {
   isLoaded: false,
 };
 
-const childrenById = (state = {}, action) => {
+const childrenById = (state = initialState.childrenById, action) => {
   switch (action.type) {
+    case commentsTypes.GET_SINGLE_COMMENT.SUCCESS: {
+      const commentKey = getPostKey(action.payload);
+      const parentKey = getParentKey(action.payload);
+      const oldComments = state[commentKey] || [];
+
+      return {
+        ...state,
+        [parentKey]: uniq([...state[parentKey], commentKey]),
+        [commentKey]: oldComments,
+      };
+    }
     case commentsTypes.GET_COMMENTS_SUCCESS:
       return {
         ...state,
@@ -21,18 +33,10 @@ const childrenById = (state = {}, action) => {
   }
 };
 
-const mapCommentsBasedOnId = (data, action) => {
+const mapCommentsBasedOnId = data => {
   const commentsList = {};
   Object.keys(data).forEach(key => {
     const comment = data[key];
-    if (
-      action.meta.reload &&
-      comment.author === action.meta.focusedComment.author &&
-      comment.permlink === action.meta.focusedComment.permlink
-    ) {
-      comment.focus = true;
-    }
-
     const newKey = getPostKey(data[key]);
 
     commentsList[newKey] = { ...comment, id: newKey };
@@ -40,21 +44,28 @@ const mapCommentsBasedOnId = (data, action) => {
   return commentsList;
 };
 
-const commentsData = (state = {}, action) => {
+const comments = (state = {}, action) => {
   switch (action.type) {
+    case commentsTypes.GET_SINGLE_COMMENT.SUCCESS: {
+      const commentKey = getPostKey(action.payload);
+
+      const comment = {
+        ...action.payload,
+        id: commentKey,
+      };
+
+      if (action.meta.focus) comment.focus = true;
+
+      return {
+        ...mapValues(state, c => omit(c, 'focus')),
+        [commentKey]: comment,
+      };
+    }
     case commentsTypes.GET_COMMENTS_SUCCESS:
       return {
         ...state,
         ...mapCommentsBasedOnId(action.payload.content, action),
       };
-    case commentsTypes.RELOAD_EXISTING_COMMENT: {
-      const key = getPostKey(action.payload);
-
-      return {
-        ...state,
-        [key]: { ...action.payload, id: key },
-      };
-    }
     default:
       return state;
   }
@@ -63,7 +74,7 @@ const commentsData = (state = {}, action) => {
 const isFetching = (state = initialState.isFetching, action) => {
   switch (action.type) {
     case commentsTypes.GET_COMMENTS_START:
-      return !action.meta.reload && true;
+      return true;
     case commentsTypes.GET_COMMENTS_SUCCESS:
     case commentsTypes.GET_COMMENTS_ERROR:
       return false;
@@ -84,47 +95,57 @@ const isLoaded = (state = initialState.isLoaded, action) => {
   }
 };
 
-const comments = (state = initialState, action) => {
+const pendingVotes = (state = initialState.pendingVotes, action) => {
   switch (action.type) {
-    case commentsTypes.GET_COMMENTS_START:
-    case commentsTypes.GET_COMMENTS_SUCCESS:
-    case commentsTypes.GET_COMMENTS_ERROR:
-      return {
-        ...state,
-        comments: commentsData(state.comments, action),
-        childrenById: childrenById(state.childrenById, action),
-        isFetching: isFetching(state.isFetching, action),
-        isLoaded: isLoaded(state.isLoaded, action),
-      };
     case commentsTypes.LIKE_COMMENT_START:
-      return {
+      return [
         ...state,
-        pendingVotes: [
-          ...state.pendingVotes,
-          {
-            id: action.meta.commentId,
-            percent: action.meta.weight,
-            vote: action.meta.vote,
-          },
-        ],
-      };
+        {
+          id: action.meta.commentId,
+          percent: action.meta.weight,
+          vote: action.meta.vote,
+        },
+      ];
     case commentsTypes.LIKE_COMMENT_ERROR:
-      return {
-        ...state,
-        pendingVotes: state.pendingVotes.filter(like => like.id !== action.meta.commentId),
-      };
-    case commentsTypes.RELOAD_EXISTING_COMMENT:
-      return {
-        ...state,
-        comments: commentsData(state.comments, action),
-        pendingVotes: state.pendingVotes.filter(like => like.id !== action.meta.commentId),
-      };
+      return state.filter(like => like.id !== action.meta.commentId);
+    case commentsTypes.GET_SINGLE_COMMENT.SUCCESS: {
+      const commentKey = getPostKey(action.payload);
+      return state.filter(({ id }) => id !== commentKey);
+    }
     default:
       return state;
   }
 };
 
-export default comments;
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case commentsTypes.GET_SINGLE_COMMENT.SUCCESS:
+      return {
+        ...state,
+        childrenById: childrenById(state.childrenById, action),
+        comments: comments(state.comments, action),
+        pendingVotes: pendingVotes(state.pendingVotes, action),
+      };
+    case commentsTypes.GET_COMMENTS_START:
+    case commentsTypes.GET_COMMENTS_SUCCESS:
+    case commentsTypes.GET_COMMENTS_ERROR:
+      return {
+        ...state,
+        comments: comments(state.comments, action),
+        childrenById: childrenById(state.childrenById, action),
+        isFetching: isFetching(state.isFetching, action),
+        isLoaded: isLoaded(state.isLoaded, action),
+      };
+    case commentsTypes.LIKE_COMMENT_START:
+    case commentsTypes.LIKE_COMMENT_ERROR:
+      return {
+        ...state,
+        pendingVotes: pendingVotes(state.pendingVotes, action),
+      };
+    default:
+      return state;
+  }
+};
 
 export const getComments = state => state;
 export const getCommentsList = state => state.comments;

--- a/src/client/components/CommentFooter/Buttons.js
+++ b/src/client/components/CommentFooter/Buttons.js
@@ -27,7 +27,7 @@ class Buttons extends React.Component {
     replying: PropTypes.bool,
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
+        id: PropTypes.string,
         percent: PropTypes.number,
       }),
     ),

--- a/src/client/components/CommentFooter/CommentFooter.js
+++ b/src/client/components/CommentFooter/CommentFooter.js
@@ -25,7 +25,7 @@ export default class CommentFooter extends React.Component {
     replying: PropTypes.bool,
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
+        id: PropTypes.string,
         percent: PropTypes.number,
       }),
     ),

--- a/src/client/components/Comments/Comment.js
+++ b/src/client/components/Comments/Comment.js
@@ -39,7 +39,7 @@ class Comment extends React.Component {
     commentsChildren: PropTypes.shape(),
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
+        id: PropTypes.string,
         percent: PropTypes.number,
       }),
     ),

--- a/src/client/components/Comments/Comments.js
+++ b/src/client/components/Comments/Comments.js
@@ -27,7 +27,7 @@ class Comments extends React.Component {
     commentsChildren: PropTypes.shape(),
     pendingVotes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
+        id: PropTypes.string,
         percent: PropTypes.number,
       }),
     ),

--- a/src/client/helpers/stateHelpers.js
+++ b/src/client/helpers/stateHelpers.js
@@ -139,3 +139,4 @@ export const createAsyncActionType = type => ({
 
 export const getUserDetailsKey = username => `user-${username}`;
 export const getPostKey = post => `${post.author}/${post.permlink}`;
+export const getParentKey = post => `${post.parent_author}/${post.parent_permlink}`;


### PR DESCRIPTION
Fixes #2151

### Changes

Summary of changes you made.

* Load comment using `get_content` after replying/editing/upvoting.
* Remove previous `focus` state on old comments.
* Update `pendingVotes`'s `id` type to `string`.

### Test plan

* [x] Go to http://localhost:3000/@hellosteem/kqj3n-test
* [x] Try upvoting a post.
* [x] Try replying.
* [x] Try updating a comment.
