### PR TITLE
fix: powering down translation

### DIFF
--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -248,6 +248,7 @@
   "steem_dollar": "Steem Dollar",
   "steem_power": "Steem Power",
   "steem_power_delegated_to_account_tooltip": "Steem Power delegated to this account",
+  "steem_power_pending_withdrawal_tooltip": "The next power down is scheduled to happen on {date} {time}",
   "savings": "Savings",
   "est_account_value": "Est. Account Value",
   "transferred_to": "Transferred to {username}",

--- a/src/client/wallet/UserWalletSummary.js
+++ b/src/client/wallet/UserWalletSummary.js
@@ -59,10 +59,12 @@ const getFormattedPendingWithdrawalSP = (user, totalVestingShares, totalVestingF
           <span>
             <FormattedMessage
               id="steem_power_pending_withdrawal_tooltip"
-              defaultMessage="The next power down is scheduled to happen on "
+              defaultMessage="The next power down is scheduled to happen on {date} {time}"
+              values={{
+                date: <FormattedDate value={`${user.next_vesting_withdrawal}Z`} />,
+                time: <FormattedTime value={`${user.next_vesting_withdrawal}Z`} />,
+              }}
             />
-            <FormattedDate value={`${user.next_vesting_withdrawal}Z`} />{' '}
-            <FormattedTime value={`${user.next_vesting_withdrawal}Z`} />
           </span>
         }
       >

--- a/src/client/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
+++ b/src/client/wallet/__tests__/__snapshots__/UserWalletSummary.test.js.snap
@@ -86,16 +86,18 @@ ShallowWrapper {
                 title={
                   <span>
                     <FormattedMessage
-                      defaultMessage="The next power down is scheduled to happen on "
+                      defaultMessage="The next power down is scheduled to happen on {date} {time}"
                       id="steem_power_pending_withdrawal_tooltip"
-                      values={Object {}}
-                    />
-                    <FormattedDate
-                      value="undefinedZ"
-                    />
-                     
-                    <FormattedTime
-                      value="undefinedZ"
+                      values={
+                        Object {
+                          "date": <FormattedDate
+                            value="undefinedZ"
+                          />,
+                          "time": <FormattedTime
+                            value="undefinedZ"
+                          />,
+                        }
+                      }
                     />
                   </span>
                 }
@@ -363,16 +365,18 @@ ShallowWrapper {
                   title={
                     <span>
                       <FormattedMessage
-                        defaultMessage="The next power down is scheduled to happen on "
+                        defaultMessage="The next power down is scheduled to happen on {date} {time}"
                         id="steem_power_pending_withdrawal_tooltip"
-                        values={Object {}}
-                      />
-                      <FormattedDate
-                        value="undefinedZ"
-                      />
-                       
-                      <FormattedTime
-                        value="undefinedZ"
+                        values={
+                          Object {
+                            "date": <FormattedDate
+                              value="undefinedZ"
+                            />,
+                            "time": <FormattedTime
+                              value="undefinedZ"
+                            />,
+                          }
+                        }
                       />
                     </span>
                   }
@@ -463,16 +467,18 @@ ShallowWrapper {
                   title={
                     <span>
                       <FormattedMessage
-                        defaultMessage="The next power down is scheduled to happen on "
+                        defaultMessage="The next power down is scheduled to happen on {date} {time}"
                         id="steem_power_pending_withdrawal_tooltip"
-                        values={Object {}}
-                      />
-                      <FormattedDate
-                        value="undefinedZ"
-                      />
-                       
-                      <FormattedTime
-                        value="undefinedZ"
+                        values={
+                          Object {
+                            "date": <FormattedDate
+                              value="undefinedZ"
+                            />,
+                            "time": <FormattedTime
+                              value="undefinedZ"
+                            />,
+                          }
+                        }
                       />
                     </span>
                   }
@@ -521,16 +527,18 @@ ShallowWrapper {
                     title={
                       <span>
                         <FormattedMessage
-                          defaultMessage="The next power down is scheduled to happen on "
+                          defaultMessage="The next power down is scheduled to happen on {date} {time}"
                           id="steem_power_pending_withdrawal_tooltip"
-                          values={Object {}}
-                        />
-                        <FormattedDate
-                          value="undefinedZ"
-                        />
-                         
-                        <FormattedTime
-                          value="undefinedZ"
+                          values={
+                            Object {
+                              "date": <FormattedDate
+                                value="undefinedZ"
+                              />,
+                              "time": <FormattedTime
+                                value="undefinedZ"
+                              />,
+                            }
+                          }
                         />
                       </span>
                     }
@@ -590,16 +598,18 @@ ShallowWrapper {
                     </span>,
                     "title": <span>
                       <FormattedMessage
-                        defaultMessage="The next power down is scheduled to happen on "
+                        defaultMessage="The next power down is scheduled to happen on {date} {time}"
                         id="steem_power_pending_withdrawal_tooltip"
-                        values={Object {}}
-                      />
-                      <FormattedDate
-                        value="undefinedZ"
-                      />
-                       
-                      <FormattedTime
-                        value="undefinedZ"
+                        values={
+                          Object {
+                            "date": <FormattedDate
+                              value="undefinedZ"
+                            />,
+                            "time": <FormattedTime
+                              value="undefinedZ"
+                            />,
+                          }
+                        }
                       />
                     </span>,
                   },
@@ -1120,16 +1130,18 @@ ShallowWrapper {
                   title={
                     <span>
                       <FormattedMessage
-                        defaultMessage="The next power down is scheduled to happen on "
+                        defaultMessage="The next power down is scheduled to happen on {date} {time}"
                         id="steem_power_pending_withdrawal_tooltip"
-                        values={Object {}}
-                      />
-                      <FormattedDate
-                        value="undefinedZ"
-                      />
-                       
-                      <FormattedTime
-                        value="undefinedZ"
+                        values={
+                          Object {
+                            "date": <FormattedDate
+                              value="undefinedZ"
+                            />,
+                            "time": <FormattedTime
+                              value="undefinedZ"
+                            />,
+                          }
+                        }
                       />
                     </span>
                   }
@@ -1397,16 +1409,18 @@ ShallowWrapper {
                     title={
                       <span>
                         <FormattedMessage
-                          defaultMessage="The next power down is scheduled to happen on "
+                          defaultMessage="The next power down is scheduled to happen on {date} {time}"
                           id="steem_power_pending_withdrawal_tooltip"
-                          values={Object {}}
-                        />
-                        <FormattedDate
-                          value="undefinedZ"
-                        />
-                         
-                        <FormattedTime
-                          value="undefinedZ"
+                          values={
+                            Object {
+                              "date": <FormattedDate
+                                value="undefinedZ"
+                              />,
+                              "time": <FormattedTime
+                                value="undefinedZ"
+                              />,
+                            }
+                          }
                         />
                       </span>
                     }
@@ -1497,16 +1511,18 @@ ShallowWrapper {
                     title={
                       <span>
                         <FormattedMessage
-                          defaultMessage="The next power down is scheduled to happen on "
+                          defaultMessage="The next power down is scheduled to happen on {date} {time}"
                           id="steem_power_pending_withdrawal_tooltip"
-                          values={Object {}}
-                        />
-                        <FormattedDate
-                          value="undefinedZ"
-                        />
-                         
-                        <FormattedTime
-                          value="undefinedZ"
+                          values={
+                            Object {
+                              "date": <FormattedDate
+                                value="undefinedZ"
+                              />,
+                              "time": <FormattedTime
+                                value="undefinedZ"
+                              />,
+                            }
+                          }
                         />
                       </span>
                     }
@@ -1555,16 +1571,18 @@ ShallowWrapper {
                       title={
                         <span>
                           <FormattedMessage
-                            defaultMessage="The next power down is scheduled to happen on "
+                            defaultMessage="The next power down is scheduled to happen on {date} {time}"
                             id="steem_power_pending_withdrawal_tooltip"
-                            values={Object {}}
-                          />
-                          <FormattedDate
-                            value="undefinedZ"
-                          />
-                           
-                          <FormattedTime
-                            value="undefinedZ"
+                            values={
+                              Object {
+                                "date": <FormattedDate
+                                  value="undefinedZ"
+                                />,
+                                "time": <FormattedTime
+                                  value="undefinedZ"
+                                />,
+                              }
+                            }
                           />
                         </span>
                       }
@@ -1624,16 +1642,18 @@ ShallowWrapper {
                       </span>,
                       "title": <span>
                         <FormattedMessage
-                          defaultMessage="The next power down is scheduled to happen on "
+                          defaultMessage="The next power down is scheduled to happen on {date} {time}"
                           id="steem_power_pending_withdrawal_tooltip"
-                          values={Object {}}
-                        />
-                        <FormattedDate
-                          value="undefinedZ"
-                        />
-                         
-                        <FormattedTime
-                          value="undefinedZ"
+                          values={
+                            Object {
+                              "date": <FormattedDate
+                                value="undefinedZ"
+                              />,
+                              "time": <FormattedTime
+                                value="undefinedZ"
+                              />,
+                            }
+                          }
                         />
                       </span>,
                     },


### PR DESCRIPTION
### Changes

* Add missing translation string.
* Use message variables instead of the hard-coded message format.

### Test plan

Explain how to test changes you made.

* [x] Check tooltip on powering down amount: http://localhost:3000/@steemit/transfers

