### PR TITLE
Show zero payout

### DIFF
--- a/src/client/components/StoryFooter/Payout.js
+++ b/src/client/components/StoryFooter/Payout.js
@@ -13,29 +13,27 @@ const Payout = ({ intl, post }) => {
   const payoutValue = payout.cashoutInTime ? payout.potentialPayout : payout.pastPayouts;
 
   return (
-    payoutValue >= 0.005 && (
-      <span className="Payout">
-        <BTooltip title={<PayoutDetail post={post} />}>
-          <span
-            className={classNames({
-              'Payout--rejected': payout.isPayoutDeclined,
-            })}
-          >
-            <USDDisplay value={payoutValue} />
-          </span>
+    <span className="Payout">
+      <BTooltip title={<PayoutDetail post={post} />}>
+        <span
+          className={classNames({
+            'Payout--rejected': payout.isPayoutDeclined,
+          })}
+        >
+          <USDDisplay value={payoutValue} />
+        </span>
+      </BTooltip>
+      {post.percent_steem_dollars === 0 && (
+        <BTooltip
+          title={intl.formatMessage({
+            id: 'reward_option_100',
+            defaultMessage: '100% Steem Power',
+          })}
+        >
+          <i className="iconfont icon-flashlight" />
         </BTooltip>
-        {post.percent_steem_dollars === 0 && (
-          <BTooltip
-            title={intl.formatMessage({
-              id: 'reward_option_100',
-              defaultMessage: '100% Steem Power',
-            })}
-          >
-            <i className="iconfont icon-flashlight" />
-          </BTooltip>
-        )}
-      </span>
-    )
+      )}
+    </span>
   );
 };
 


### PR DESCRIPTION
Fixes #2173 

### Changes

* Show ~~$0.00~~ for payout-declined post all the time
* Show $0.00 or ~~$0.00~~ depending on the declined status even for posts with pending payout lower than $0.005.

### Test plan

Explain how to test changes you made.

* [ ] https://busy.org/@ned/the-guiding-mission-vision-and-values-of-steemit-inc should show ~~$0.00~~ instead of nothing
* [ ] Create any post. It should show either $0.00 or ~~$0.00~~ depending on the declined status from the beginning.

### Demo (optional)
##### Before
https://busy.org/@ned/the-guiding-mission-vision-and-values-of-steemit-inc

![](https://cdn.steemitimages.com/DQmQEP9M8ef7Gc6kJ8j5AdAdSmh9BiFF6jwpgQrdXHYRSD2/Screen%20Shot%202019-01-28%20at%203.50.20%20PM.png)
> Currently, Busy shows nothing when payout is zero. So it's hard to tell whether it's due to downvoting or decline.

As explained in the proposal, this might be more serious when a post has just been posted. Before voting, no way to tell whether the post is payout-declined or not.

##### After
![](https://cdn.steemitimages.com/DQmafbeeHfzq1q3JTW6CJNiriKYAg5Cmh8jgqAzPgcammZq/Screen%20Shot%202019-01-28%20at%205.46.20%20PM.png)
> Busy should show it as ~~$0.00~~ for both posts just posted and paid out.
