### PR TITLE
Fix 2175: 3-digit precision

### DIFF
--- a/src/client/components/Utils/USDDisplay.js
+++ b/src/client/components/Utils/USDDisplay.js
@@ -6,7 +6,7 @@ const USDDisplay = ({ value }) => {
   const negative = value < 0;
   const absValue = Math.abs(value);
   // 0.02 is dust payout threshold (STEEM_MIN_PAYOUT_SBD)
-  const precision = absValue < 0.02 && value > 0 ? 3 : 2;
+  const precision = absValue < 0.02 && absValue > 0 ? 3 : 2;
   return (
     <span>
       {negative && '-'}

--- a/src/client/components/Utils/USDDisplay.js
+++ b/src/client/components/Utils/USDDisplay.js
@@ -5,11 +5,16 @@ import { FormattedNumber } from 'react-intl';
 const USDDisplay = ({ value }) => {
   const negative = value.toFixed(2) < 0;
   const absValue = Math.abs(value);
+  const precision = absValue < 0.02 && absValue > 0 ? 3 : 2;
   return (
     <span>
       {negative && '-'}
       {'$'}
-      <FormattedNumber value={absValue} minimumFractionDigits={2} maximumFractionDigits={2} />
+      <FormattedNumber
+        value={absValue}
+        minimumFractionDigits={precision}
+        maximumFractionDigits={precision}
+      />
     </span>
   );
 };

--- a/src/client/components/Utils/USDDisplay.js
+++ b/src/client/components/Utils/USDDisplay.js
@@ -5,7 +5,7 @@ import { FormattedNumber } from 'react-intl';
 const USDDisplay = ({ value }) => {
   const negative = value.toFixed(2) < 0;
   const absValue = Math.abs(value);
-  const precision = absValue < 0.02 && absValue > 0 ? 3 : 2;
+  const precision = absValue < 0.02 && value > 0 ? 3 : 2;
   return (
     <span>
       {negative && '-'}

--- a/src/client/components/Utils/USDDisplay.js
+++ b/src/client/components/Utils/USDDisplay.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { FormattedNumber } from 'react-intl';
 
 const USDDisplay = ({ value }) => {
-  const negative = value.toFixed(2) < 0;
+  const negative = value < 0;
   const absValue = Math.abs(value);
+  // 0.02 is dust payout threshold (STEEM_MIN_PAYOUT_SBD)
   const precision = absValue < 0.02 && value > 0 ? 3 : 2;
   return (
     <span>

--- a/src/client/components/__tests__/USSDDisplay.js
+++ b/src/client/components/__tests__/USSDDisplay.js
@@ -25,4 +25,9 @@ describe('<USSDDisplay />', () => {
     const wrapper = getWrapper(-0.001);
     expect(wrapper.text()).toEqual('$0.00');
   });
+
+  it('handle small numebrs < $0.02', () => {
+    const wrapper = getWrapper(0.017);
+    expect(wrapper.text()).toEqual('$0.017');
+  });
 });

--- a/src/client/components/__tests__/USSDDisplay.js
+++ b/src/client/components/__tests__/USSDDisplay.js
@@ -16,18 +16,18 @@ describe('<USSDDisplay />', () => {
     expect(wrapper.text()).toEqual('$44.36');
   });
 
+  it('handle small positive numbers < $0.02 properly', () => {
+    const wrapper = getWrapper(0.017);
+    expect(wrapper.text()).toEqual('$0.017');
+  });
+
   it('handles negative values properly', () => {
     const wrapper = getWrapper(-1.33);
     expect(wrapper.text()).toEqual('-$1.33');
   });
 
-  it('skips - for number small negative numebrs', () => {
+  it('handle small negative numbers properly. negative numbers always have 2-digit precision', () => {
     const wrapper = getWrapper(-0.001);
-    expect(wrapper.text()).toEqual('$0.00');
-  });
-
-  it('handle small numebrs < $0.02', () => {
-    const wrapper = getWrapper(0.017);
-    expect(wrapper.text()).toEqual('$0.017');
+    expect(wrapper.text()).toEqual('-$0.00');
   });
 });

--- a/src/client/components/__tests__/USSDDisplay.js
+++ b/src/client/components/__tests__/USSDDisplay.js
@@ -26,8 +26,18 @@ describe('<USSDDisplay />', () => {
     expect(wrapper.text()).toEqual('-$1.33');
   });
 
-  it('handle small negative numbers properly. negative numbers always have 2-digit precision', () => {
+  it('handle small negative numbers properly.', () => {
     const wrapper = getWrapper(-0.001);
-    expect(wrapper.text()).toEqual('-$0.00');
+    expect(wrapper.text()).toEqual('-$0.001');
+  });
+
+  it('handle zero properly.', () => {
+    const wrapper = getWrapper(0);
+    expect(wrapper.text()).toEqual('$0.00');
+  });
+
+  it('handle negative zero properly.', () => {
+    const wrapper = getWrapper(-0);
+    expect(wrapper.text()).toEqual('$0.00');
   });
 });


### PR DESCRIPTION
Fixes #2175 

### Changes

* 3-digit precision when 0 < STU < $0.02
* 2-digit precision for all negative values
* negative values always have - sign.
* Test codes are added and modified for these.

### Test plan

* [ ] Pick any user whose voting value is less than $0.02, it should be shown up to 3-digit. For users whose voting value is at least $0.02, it should still be shown up to 2-digit.
* [ ] Do the same test for vote details for upvote and downvote

### Demo (optional)

![](https://cdn.steemitimages.com/DQmfYm6pZ5MjMWQReh7iaM1M8acMUDTjEzStPLStT17VXzS)
> before

![](https://cdn.steemitimages.com/DQmabD6eXc91JXZUHWrczTRX2uTwPYVktCpwBSroSBQrYdE)
> after

![](https://cdn.steemitimages.com/DQmQ6KGnmd9xypasiZEFguxuDW2mCrkoHA6Nxdd6zfUDJ8Q)
> but still 2-digit for >= $0.02

![](https://cdn.steemitimages.com/DQmWC6GSECYdmznQHV6H94pnyWKJxvkURCHvr5mhFVnMPTJ)
> voting details
