### PR TITLE
Fix 2179 remove US$ and 3-digit for small values

### DIFF
--- a/src/client/components/Slider/Slider.js
+++ b/src/client/components/Slider/Slider.js
@@ -8,7 +8,6 @@ import './Slider.less';
 @injectIntl
 export default class Slider extends React.Component {
   static propTypes = {
-    intl: PropTypes.shape().isRequired,
     value: PropTypes.number,
     voteWorth: PropTypes.number,
     onChange: PropTypes.func,
@@ -46,12 +45,6 @@ export default class Slider extends React.Component {
 
   getCurrentValue = () => this.props.voteWorth;
 
-  getCurrentFormattedValue = () =>
-    this.props.intl.formatNumber(this.getCurrentValue(), {
-      style: 'currency',
-      currency: 'USD',
-    });
-
   handleChange = value => {
     this.setState({ value }, () => {
       this.props.onChange(value);
@@ -87,9 +80,7 @@ export default class Slider extends React.Component {
               id="like_slider_info"
               defaultMessage="Your vote will be worth {amount}."
               values={{
-                amount: (
-                  <span className="Slider__info__amount">{this.getCurrentFormattedValue()}</span>
-                ),
+                amount: <USDDisplay value={this.getCurrentValue()} />,
               }}
             />
           </h3>


### PR DESCRIPTION
Fixes #2179 

### Changes

* Remove `US` in `US$` in non-English languages
* 3-digit precision for smaller than $0.02 (#2175 )

### Test plan

* [ ] Set language (e.g., Korean) different from English in the setting.
* [ ] Enable voting power slider
* [ ] Vote with varying voting power

### Demo (optional)
![](https://user-images.githubusercontent.com/38183982/52060426-17eee400-2564-11e9-9c13-df1cb5c4f960.png)
> before

![](https://user-images.githubusercontent.com/38183982/52060900-2093ea00-2565-11e9-8054-25d6ac26f72e.png)
> after < $0.02

![](https://user-images.githubusercontent.com/38183982/52060930-2ee20600-2565-11e9-9889-cc89544ab778.png)
> after >= $0.02

