### PR TITLE
fix: couldn't reblog with multiple accounts

### DIFF
--- a/src/client/Wrapper.js
+++ b/src/client/Wrapper.js
@@ -140,10 +140,10 @@ export default class Wrapper extends React.PureComponent {
       this.props.getFollowing();
       this.props.getNotifications();
       this.props.busyLogin();
+      this.props.getRebloggedList();
     });
 
     this.props.getRewardFund();
-    this.props.getRebloggedList();
     this.props.getRate();
     this.props.getTrendingTopics();
   }

--- a/src/client/app/Reblog/reblogActions.js
+++ b/src/client/app/Reblog/reblogActions.js
@@ -7,7 +7,9 @@ export const REBLOG_POST_SUCCESS = '@reblog/REBLOG_POST_SUCCESS';
 export const REBLOG_POST_ERROR = '@reblog/REBLOG_POST_ERROR';
 
 export const GET_REBLOGGED_LIST = '@reblog/GET_REBLOGGED_LIST';
+export const CLEAR_REBLOGGED_LIST = '@reblog/CLEAR_REBLOGGED_LIST';
 const getRebloggedListAction = createAction(GET_REBLOGGED_LIST);
+export const clearRebloggedList = createAction(CLEAR_REBLOGGED_LIST);
 
 // We need to use the store, because at this time there is no way to receive user's reblogs via SteemConnect API
 const storePostId = (postId, username) => {

--- a/src/client/app/Reblog/reblogActions.js
+++ b/src/client/app/Reblog/reblogActions.js
@@ -9,22 +9,27 @@ export const REBLOG_POST_ERROR = '@reblog/REBLOG_POST_ERROR';
 export const GET_REBLOGGED_LIST = '@reblog/GET_REBLOGGED_LIST';
 const getRebloggedListAction = createAction(GET_REBLOGGED_LIST);
 
-const storePostId = postId => {
-  const reblogged = store.get('reblogged') || [];
-  const newReblogged = [...reblogged, postId];
+// We need to use the store, because at this time there is no way to receive user's reblogs via SteemConnect API
+const storePostId = (postId, username) => {
+  const reblogged = store.get('reblogged') || {};
+  const userReblogs = reblogged.username || [];
+
+  const newUserReblogs = [...userReblogs, postId];
+  const newReblogged = { ...reblogged, [username]: newUserReblogs };
   store.set('reblogged', newReblogged);
-  return newReblogged;
+  return newUserReblogs; // only current user's reblogs
 };
 
 export const reblog = postId => (dispatch, getState, { steemConnectAPI }) => {
   const { auth, posts } = getState();
   const post = posts.list[postId];
+  const { name } = auth.user;
 
   dispatch({
     type: REBLOG_POST,
     payload: {
-      promise: steemConnectAPI.reblog(auth.user.name, post.author, post.permlink).then(result => {
-        const list = storePostId(postId);
+      promise: steemConnectAPI.reblog(name, post.author, post.permlink).then(result => {
+        const list = storePostId(postId, name);
         dispatch(getRebloggedListAction(list));
 
         if (window.analytics) {
@@ -42,7 +47,8 @@ export const reblog = postId => (dispatch, getState, { steemConnectAPI }) => {
   });
 };
 
-export const getRebloggedList = () => dispatch => {
-  const list = store.get('reblogged') || [];
-  dispatch(getRebloggedListAction(list));
+export const getRebloggedList = () => (dispatch, getState) => {
+  const { auth: { user: { name } } } = getState();
+  const { [name]: userReblogs = [] } = store.get('reblogged') || {};
+  dispatch(getRebloggedListAction(userReblogs));
 };

--- a/src/client/app/Reblog/reblogReducers.js
+++ b/src/client/app/Reblog/reblogReducers.js
@@ -12,6 +12,11 @@ const reblogReducer = (state = initialState, action) => {
         ...state,
         rebloggedList: action.payload,
       };
+    case reblogActions.CLEAR_REBLOGGED_LIST:
+      return {
+        ...state,
+        rebloggedList: [],
+      };
     case reblogActions.REBLOG_POST_START:
       return {
         ...state,

--- a/src/client/auth/authActions.js
+++ b/src/client/auth/authActions.js
@@ -4,6 +4,7 @@ import { getAuthenticatedUserName, getIsAuthenticated, getIsLoaded } from '../re
 import { createAsyncActionType } from '../helpers/stateHelpers';
 import { addNewNotification } from '../app/appActions';
 import { getFollowing } from '../user/userActions';
+import { clearRebloggedList } from '../app/Reblog/reblogActions';
 import { BUSY_API_TYPES } from '../../common/constants/notifications';
 
 export const LOGIN = '@auth/LOGIN';
@@ -64,6 +65,8 @@ export const logout = () => (dispatch, getState, { steemConnectAPI }) => {
   dispatch({
     type: LOGOUT,
   });
+
+  dispatch(clearRebloggedList());
 };
 
 export const getUpdatedSCUserMetadata = () => (dispatch, getState, { steemConnectAPI }) =>


### PR DESCRIPTION
Fixes #2081 

### Changes

* Made reblogs to be stored per user rather than per app

### Test plan

* [ ] Log in with account A
* [ ] Reblog a post
* [ ] Log out
* [ ] Log in with account B
* [ ] Reblog the same post
