### PR TITLE
don't show beneficiary setting for editing

### DIFF
--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -355,19 +355,21 @@ class Editor extends React.Component {
             </Select>,
           )}
         </Form.Item>
-        <Form.Item>
-          {getFieldDecorator('beneficiary', { valuePropName: 'checked', initialValue: true })(
-            <Checkbox onChange={this.onUpdate} disabled={isUpdating}>
-              <FormattedMessage
-                id="add_busy_beneficiary"
-                defaultMessage="Share {share}% of this post rewards with Busy"
-                values={{
-                  share: BENEFICIARY_PERCENT / 100,
-                }}
-              />
-            </Checkbox>,
-          )}
-        </Form.Item>
+        {!isUpdating && ( // don't show for editing
+          <Form.Item>
+            {getFieldDecorator('beneficiary', { valuePropName: 'checked', initialValue: true })(
+              <Checkbox onChange={this.onUpdate} disabled={isUpdating}>
+                <FormattedMessage
+                  id="add_busy_beneficiary"
+                  defaultMessage="Share {share}% of this post rewards with Busy"
+                  values={{
+                    share: BENEFICIARY_PERCENT / 100,
+                  }}
+                />
+              </Checkbox>,
+            )}
+          </Form.Item>
+        )}
         <div className="Editor__bottom">
           <span className="Editor__bottom__info">
             <i className="iconfont icon-markdown" />{' '}


### PR DESCRIPTION
Fixes #2194

### Changes

* Don't show beneficiary setting in the editing mode. (Of course, still showing in the creating mode. Don't worry)

### Test plan

* [ ] Edit any post.
* [ ] Beneficiary setting shouldn't show up.
* [ ] Creat a post.
* [ ] Beneficiary setting should show. :(

### Demo 
#### Before
![](https://user-images.githubusercontent.com/38183982/53601968-513b6380-3ba5-11e9-8ddf-a22cd8484bb8.png)
> Currently, regardless of the original beneficiary setting, it is shown as checked (while disabled). This can be quite confusing to normal users even though beneficiary setting can't be changed after the initial posting.

#### After

beneficiary setting shouldn't show for editing.

![](https://user-images.githubusercontent.com/38183982/53601958-4aacec00-3ba5-11e9-8a44-638df06d4c31.png)