### PR TITLE
multiple links support in one sentence

### DIFF
--- a/src/client/vendor/steemitHtmlReady.js
+++ b/src/client/vendor/steemitHtmlReady.js
@@ -7,7 +7,7 @@
 import embedjs from 'embedjs';
 import slice from 'lodash/slice';
 import xmldom from 'xmldom';
-import linksRe from './steemitLinks';
+import linksRe, { any as linksAny } from './steemitLinks';
 import { validateAccountName } from './ChainValidation';
 import { getProxyImageURL } from '../helpers/image';
 
@@ -246,7 +246,8 @@ function linkify(content, mutate, hashtags, usertags, images, links) {
     },
   );
 
-  content = content.replace(linksRe.any, ln => {
+  content = content.replace(linksAny('gi'), ln => {
+    console.log(ln);
     if (linksRe.image.test(ln)) {
       if (images) images.add(ln);
       return `<img src="${ln}" />`;


### PR DESCRIPTION
Fix #2197

### Changes


* Multiple links support in one sentence

### Test plan

* [ ] Create a post with at least two links in one sentence.
* [ ] Check if they are shown as hyperlinks.

### Demo (optional)

#### Before 

Visit https://busy.org/@blockchainstudio/steem-keychain-should-hide-private-keys-by-default

![](https://user-images.githubusercontent.com/38183982/54165177-8a9e8980-4457-11e9-9447-92c381d42328.png)


#### After
![](https://user-images.githubusercontent.com/38183982/54165548-12d15e80-4459-11e9-96fd-d52181bcb3d2.png)

