### PR TITLE
fixed background color of highlighted search result in nightmode

### DIFF
--- a/src/client/components/Navigation/Topnav-nightmode.less
+++ b/src/client/components/Navigation/Topnav-nightmode.less
@@ -46,7 +46,9 @@
     border-bottom: @border-width-base @border-style-base @normal-grey;
   }
 
-  .Topnav__search-autocomplete.ant-select-dropdown-menu-item-active {
+  .Topnav__search-autocomplete.ant-select-dropdown-menu-item-active,
+  .Topnav__search-autocomplete.ant-select-dropdown-menu-item-selected {
+    background-color: #43484d;
     &:hover {
       background-color: #32373c;
     }


### PR DESCRIPTION
### Changes

Just some minor CSS fix...

### Test plan

Search for an exact username. The username will be highlighted in the search results.

### Demo (optional)

Before:
![busy-search-before](https://user-images.githubusercontent.com/6792578/58903885-b94e9800-8706-11e9-9f5b-ef07f2013cbc.png)

After:
![busy-search-after](https://user-images.githubusercontent.com/6792578/58903896-bfdd0f80-8706-11e9-9d0a-0704060289ca.png)
