### PR TITLE
increase tag limit to 12

### DIFF
--- a/src/client/components/Editor/Editor.js
+++ b/src/client/components/Editor/Editor.js
@@ -14,7 +14,7 @@ import withEditor from './withEditor';
 import EditorInput from './EditorInput';
 import { remarkable } from '../Story/Body';
 import BodyContainer from '../../containers/Story/BodyContainer';
-import { BENEFICIARY_PERCENT } from '../../helpers/constants';
+import { BENEFICIARY_PERCENT, MAX_TAG } from '../../helpers/constants';
 import './Editor.less';
 
 @injectIntl
@@ -141,12 +141,17 @@ class Editor extends React.Component {
   }
 
   checkTopics = intl => (rule, value, callback) => {
-    if (!value || value.length < 1 || value.length > 5) {
+    if (!value || value.length < 1 || value.length > MAX_TAG) {
       callback(
-        intl.formatMessage({
-          id: 'topics_error_count',
-          defaultMessage: 'You have to add 1 to 5 topics.',
-        }),
+        intl.formatMessage(
+          {
+            id: 'topics_error_max_tag',
+            defaultMessage: 'You have to add 1 to {max_tag} topics.',
+          },
+          {
+            max_tag: MAX_TAG,
+          },
+        ),
       );
     }
 

--- a/src/client/helpers/constants.js
+++ b/src/client/helpers/constants.js
@@ -1,6 +1,7 @@
 export const BENEFICIARY_ACCOUNT = 'busy.org';
 export const BENEFICIARY_PERCENT = 1000;
 export const REFERRAL_PERCENT = 1000;
+export const MAX_TAG = 12; // to support SCOT tokens. but some Steem API may not work properly for more than 5 tags.
 
 export const knownDomains = [
   'busy.org',


### PR DESCRIPTION
Fixes #2211

### Changes

To support various SCOT tokens, increase max number of tags to 12.

* max number of tags is now 12 (from 5)
* constant `MAX_TAG` is defined for a change in the future
* intl message with id `topics_error_max_tag` is created

### Test plan

Explain how to test changes you made.

* [ ] write/edit a post with more than 5 tags.
* [ ] try to use more than 12 tags, then you should get an error

### Demo (optional)

<img width="736" src="https://user-images.githubusercontent.com/38183982/61553159-acd19500-aa51-11e9-9acc-f46ecb16915b.png">
> now support more than 5 tags

<img width="740" src="https://user-images.githubusercontent.com/38183982/61553170-b529d000-aa51-11e9-9ad2-6a3bb2ab0a1e.png">
> but up to 12 tags

