### PR TITLE
fix zero payout with 100% beneficiary

### DIFF
--- a/src/client/components/PayoutDetail.js
+++ b/src/client/components/PayoutDetail.js
@@ -104,6 +104,7 @@ const PayoutDetail = ({ intl, post }) => {
             defaultMessage="Total Past Payouts: {amount}"
             amount={pastPayouts}
           />
+          {beneficaries}
           <AmountWithLabel
             id="payout_author_payout_amount"
             defaultMessage="Author Payout: {amount}"

--- a/src/client/vendor/steemitHelpers.js
+++ b/src/client/vendor/steemitHelpers.js
@@ -81,7 +81,8 @@ export const calculatePayout = post => {
     payoutDetails.maxAcceptedPayout = max_payout;
   }
 
-  if (total_author_payout > 0) {
+  // payout should be used instead of total_author_payout for 100% beneficiary case (e.g., @finex)
+  if (payout > 0) {
     payoutDetails.pastPayouts = total_author_payout + total_curator_payout;
     payoutDetails.authorPayouts = total_author_payout;
     payoutDetails.curatorPayouts = total_curator_payout;


### PR DESCRIPTION
Fixes #2218 

### Changes

* Show beneficiary info for paid out posts (a user may think payout is less than expected otherwise)
* Show curator payout for 100% beneficiary post

### Test plan

* [ ] Visit any post with 100% beneficiary, e.g., https://busy.org/@blockchainstudio/finex-steem-power-liquify
* [ ] Check if beneficiary info is shown
* [ ] Check if curator payout is shown.
* [ ] Visit any post with < 100% beneficiary, e.g., https://busy.org/@blockchainstudio/busy-supports-12-tag-est-account-value-fix-multiple-links-fix

### Demo (optional)

![](https://user-images.githubusercontent.com/38183982/62006932-49292500-b13f-11e9-8ca3-46c9a7764497.png)

> before (with 100% beneficiary) https://busy.org/@blockchainstudio/finex-steem-power-liquify
- no beneficiary info
- zero payout

<br>
![](https://user-images.githubusercontent.com/38183982/62006930-45959e00-b13f-11e9-9a73-07c7beba8488.png)

> after (with 100% beneficiary)
- benefiary info
- curator payout (as Steemit shows)

<br>
![](https://user-images.githubusercontent.com/38183982/62006926-3adb0900-b13f-11e9-95ec-c5e3ee1d8f3e.png)

> before (with 5% beneficiary) https://busy.org/@blockchainstudio/busy-supports-12-tag-est-account-value-fix-multiple-links-fix
- no beneficiary info

<br>
![](https://user-images.githubusercontent.com/38183982/62006915-1ed76780-b13f-11e9-8d4a-33e210dfb02b.png)

> after (with 5% beneficiary)
- beneficiary info