### PR TITLE
total payout including beneficiaries

### DIFF
--- a/src/client/components/PayoutDetail.js
+++ b/src/client/components/PayoutDetail.js
@@ -46,6 +46,7 @@ const getBeneficaries = post => {
 
   return _.map(beneficiaries, user => (
     <p key={user.account}>
+      {' - '}
       <Link to={`/@${user.account}`}>{user.account}</Link>{' '}
       <span style={{ opacity: '0.5' }}>{getBeneficiariesPercent(user)}</span>
     </p>
@@ -59,9 +60,10 @@ const PayoutDetail = ({ intl, post }) => {
     promotionCost,
     cashoutInTime,
     isPayoutDeclined,
-    pastPayouts,
     authorPayouts,
     curatorPayouts,
+    beneficiariesPayouts,
+    totalPastPayouts,
   } = calculatePayout(post);
   const beneficaries = getBeneficaries(post);
 
@@ -90,6 +92,7 @@ const PayoutDetail = ({ intl, post }) => {
             defaultMessage="Potential Payout: {amount}"
             amount={potentialPayout}
           />
+          <FormattedMessage id="beneficiaries" defaultMessage="Beneficiaries" />
           {beneficaries}
           <FormattedMessage
             id="payout_will_release_in_time"
@@ -102,7 +105,12 @@ const PayoutDetail = ({ intl, post }) => {
           <AmountWithLabel
             id="payout_total_past_payout_amount"
             defaultMessage="Total Past Payouts: {amount}"
-            amount={pastPayouts}
+            amount={totalPastPayouts}
+          />
+          <AmountWithLabel
+            id="payout_beneficiaries_payout_amount"
+            defaultMessage="Beneficiaries payout: {amount}"
+            amount={beneficiariesPayouts}
           />
           {beneficaries}
           <AmountWithLabel

--- a/src/client/components/StoryFooter/Payout.js
+++ b/src/client/components/StoryFooter/Payout.js
@@ -10,7 +10,9 @@ import './Payout.less';
 
 const Payout = ({ intl, post }) => {
   const payout = calculatePayout(post);
-  const payoutValue = payout.cashoutInTime ? payout.potentialPayout : payout.pastPayouts;
+
+  // to support estimated total past payout including beneficiaires: https://github.com/busyorg/busy/issues/2220
+  const payoutValue = payout.cashoutInTime ? payout.potentialPayout : payout.totalPastPayouts;
 
   return (
     <span className="Payout">

--- a/src/client/helpers/constants.js
+++ b/src/client/helpers/constants.js
@@ -3,6 +3,12 @@ export const BENEFICIARY_PERCENT = 1000;
 export const REFERRAL_PERCENT = 1000;
 export const MAX_TAG = 12; // to support SCOT tokens. but some Steem API may not work properly for more than 5 tags.
 
+// to support total past payout including beneficiaires: https://github.com/busyorg/busy/issues/2220
+// Expected HF21 time: https://github.com/steemit/steem/blob/master/libraries/protocol/hardfork.d/0_21.hf
+export const HF21_TIME = '2019-08-27T15:00:00';
+export const DEFAULT_CURATION_REWARD_PERCENT = 25;
+export const HF21_CURATION_REWARD_PERCENT = 50;
+
 export const knownDomains = [
   'busy.org',
   'staging.busy.org',


### PR DESCRIPTION
Fixes #2220

### Changes

Previously, whereas pending payout includes beneficiary payout, past payout doesn't include beneficiary payout, which is inconsistent and discontinuous.

details: http://busy.org/@blockchainstudio/beneficiary-payout-amount-for-paid-out-posts

* Now past payout also includes beneficiary payout, and beneficiary payout is also separately shown.
* If beneficiary is not set, it's the same as before 
* If beneficiary is set, it shows the beneficiary payout and total also includes this.

### Test plan

* [ ] Visit any paid out post with beneficiary setting
* [ ] Check if beneficiary payout is shown and total also includes this.
* [ ] Visit any paid out post without beneficiary setting
* [ ] Visit any pending post with/without beneficiary setting 


### Demo (optional)

##### Before
<img width="601" src="https://user-images.githubusercontent.com/38183982/62013236-9f21bb00-b187-11e9-84d5-fe312e6adde2.png">

- no beneficiaries payout amount is shown and it isn't included in the total, which is inconsistent with the pending total payout that includes everything.

##### After
<img width="605" src="https://user-images.githubusercontent.com/38183982/62013220-713c7680-b187-11e9-8513-62401af4e7c0.png">

- This is an actual implementation screenshot on my dev server.
- now beneficiaries payout amount is shown and included in the total payout.

##### Before
<img width="604" src="https://user-images.githubusercontent.com/38183982/62013237-a3e66f00-b187-11e9-9d3b-1937cbd04847.png">

- In particular, this difference can be quite significant when beneficiary percentage is high, e.g., 100%

##### After
<img width="617" src="https://user-images.githubusercontent.com/38183982/62013221-7699c100-b187-11e9-8dd2-21f2e1cdaf59.png">
